### PR TITLE
Fix typo "reaosns" -> "reasons" in dpv:Justification

### DIFF
--- a/code/vocab_csv/Context.csv
+++ b/code/vocab_csv/Context.csv
@@ -12,7 +12,7 @@ NotRequired,Not Required,Indication of neither being required nor optional i.e. 
 ,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,
 Scope,Scope,Indication of the extent or range or boundaries associated with(in) a context,dpv:Context,sc,,,,,,2022-06-15,,accepted,Harshvardhan J. Pandit,https://www.w3.org/2022/06/15-dpvcg-minutes.html,,,,,,,,,,,,,,,
-Justification,Justification,"A form of documentation providing reaosns, explanations, or justifications",dpv:Context,sc,,,,,,2022-06-15,,accepted,Harshvardhan J. Pandit,https://www.w3.org/2022/06/15-dpvcg-minutes.html,,,,,,,,,,,,,,,
+Justification,Justification,"A form of documentation providing reasons, explanations, or justifications",dpv:Context,sc,,,,,,2022-06-15,,accepted,Harshvardhan J. Pandit,https://www.w3.org/2022/06/15-dpvcg-minutes.html,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,
 Frequency,Frequency,The frequency or information about periods and repetitions in terms of recurrence.,dpv:Context,sc,,,,,,2022-02-16,,accepted,Harshvardhan J. Pandit,https://www.w3.org/2022/03/23-dpvcg-minutes.html,,,,,,,,,,,,,,,
 ContinousFrequency,Continous Frequency,Frequency where occurences are continous,,dpv:Frequency,,,,,,2022-06-15,2020-10-05,accepted,Harshvardhan J. Pandit,https://www.w3.org/2022/06/15-dpvcg-minutes.html,,,,,,,,,,,,,,,

--- a/dpv/dpv-en.html
+++ b/dpv/dpv-en.html
@@ -2307,7 +2307,7 @@
 </ul>
   </li>
   <li>
-    <strong>dpv:Justification</strong>: A form of documentation providing reaosns, explanations, or justifications 
+    <strong>dpv:Justification</strong>: A form of documentation providing reasons, explanations, or justifications 
       <small><a href="https://w3id.org/dpv#Justification">go to full definition</a></small>
       
   </li>
@@ -25132,7 +25132,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/dpv-owl.html
+++ b/dpv/dpv-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/dpv-owl.jsonld
+++ b/dpv/dpv-owl.jsonld
@@ -6056,7 +6056,7 @@
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "A form of documentation providing reaosns, explanations, or justifications"
+        "@value": "A form of documentation providing reasons, explanations, or justifications"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [

--- a/dpv/dpv-owl.n3
+++ b/dpv/dpv-owl.n3
@@ -3188,7 +3188,7 @@ dpv-owl:Justification a rdfs:Class,
     rdfs:isDefinedBy dpv-owl: ;
     rdfs:subClassOf dpv-owl:Context ;
     sw:term_status "accepted"@en ;
-    skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en ;
+    skos:definition "A form of documentation providing reasons, explanations, or justifications"@en ;
     skos:prefLabel "Justification"@en .
 
 dpv-owl:LargeDataVolume a rdfs:Class,

--- a/dpv/dpv-owl.omn
+++ b/dpv/dpv-owl.omn
@@ -4015,7 +4015,7 @@ Class: <https://w3id.org/dpv#Justification>
 
     Annotations: 
         rdfs:isDefinedBy <https://w3id.org/dpv#>,
-        skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en,
+        skos:definition "A form of documentation providing reasons, explanations, or justifications"@en,
         skos:prefLabel "Justification"@en
     
     SubClassOf: 

--- a/dpv/dpv-owl.owl
+++ b/dpv/dpv-owl.owl
@@ -2427,7 +2427,7 @@
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
     <skos:prefLabel xml:lang="en">Justification</skos:prefLabel>
-    <skos:definition xml:lang="en">A form of documentation providing reaosns, explanations, or justifications</skos:definition>
+    <skos:definition xml:lang="en">A form of documentation providing reasons, explanations, or justifications</skos:definition>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/dpv/owl#"/>
     <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-06-15</dct:created>
     <rdfs:subClassOf rdf:resource="https://w3id.org/dpv/owl#Context"/>

--- a/dpv/dpv-owl.ttl
+++ b/dpv/dpv-owl.ttl
@@ -3188,7 +3188,7 @@ dpv-owl:Justification a rdfs:Class,
     rdfs:isDefinedBy dpv-owl: ;
     rdfs:subClassOf dpv-owl:Context ;
     sw:term_status "accepted"@en ;
-    skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en ;
+    skos:definition "A form of documentation providing reasons, explanations, or justifications"@en ;
     skos:prefLabel "Justification"@en .
 
 dpv-owl:LargeDataVolume a rdfs:Class,

--- a/dpv/dpv.html
+++ b/dpv/dpv.html
@@ -2307,7 +2307,7 @@
 </ul>
   </li>
   <li>
-    <strong>dpv:Justification</strong>: A form of documentation providing reaosns, explanations, or justifications 
+    <strong>dpv:Justification</strong>: A form of documentation providing reasons, explanations, or justifications 
       <small><a href="https://w3id.org/dpv#Justification">go to full definition</a></small>
       
   </li>
@@ -25132,7 +25132,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/dpv.jsonld
+++ b/dpv/dpv.jsonld
@@ -8200,7 +8200,7 @@
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "A form of documentation providing reaosns, explanations, or justifications"
+        "@value": "A form of documentation providing reasons, explanations, or justifications"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [

--- a/dpv/dpv.n3
+++ b/dpv/dpv.n3
@@ -3524,7 +3524,7 @@ dpv:Justification a rdfs:Class,
     rdfs:subClassOf dpv:Context ;
     sw:term_status "accepted"@en ;
     skos:broader dpv:Context ;
-    skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en ;
+    skos:definition "A form of documentation providing reasons, explanations, or justifications"@en ;
     skos:inScheme dpv:context-classes ;
     skos:prefLabel "Justification"@en .
 

--- a/dpv/dpv.rdf
+++ b/dpv/dpv.rdf
@@ -3701,7 +3701,7 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
     <skos:prefLabel xml:lang="en">Justification</skos:prefLabel>
-    <skos:definition xml:lang="en">A form of documentation providing reaosns, explanations, or justifications</skos:definition>
+    <skos:definition xml:lang="en">A form of documentation providing reasons, explanations, or justifications</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/dpv#Context"/>
     <skos:broader rdf:resource="https://w3id.org/dpv#Context"/>
     <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-06-15</dct:created>

--- a/dpv/dpv.ttl
+++ b/dpv/dpv.ttl
@@ -3524,7 +3524,7 @@ dpv:Justification a rdfs:Class,
     rdfs:subClassOf dpv:Context ;
     sw:term_status "accepted"@en ;
     skos:broader dpv:Context ;
-    skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en ;
+    skos:definition "A form of documentation providing reasons, explanations, or justifications"@en ;
     skos:inScheme dpv:context-classes ;
     skos:prefLabel "Justification"@en .
 

--- a/dpv/index-en.html
+++ b/dpv/index-en.html
@@ -2307,7 +2307,7 @@
 </ul>
   </li>
   <li>
-    <strong>dpv:Justification</strong>: A form of documentation providing reaosns, explanations, or justifications 
+    <strong>dpv:Justification</strong>: A form of documentation providing reasons, explanations, or justifications 
       <small><a href="https://w3id.org/dpv#Justification">go to full definition</a></small>
       
   </li>
@@ -25132,7 +25132,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/index.html
+++ b/dpv/index.html
@@ -2307,7 +2307,7 @@
 </ul>
   </li>
   <li>
-    <strong>dpv:Justification</strong>: A form of documentation providing reaosns, explanations, or justifications 
+    <strong>dpv:Justification</strong>: A form of documentation providing reasons, explanations, or justifications 
       <small><a href="https://w3id.org/dpv#Justification">go to full definition</a></small>
       
   </li>
@@ -25132,7 +25132,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/TOM-owl.html
+++ b/dpv/modules/TOM-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/context-en.html
+++ b/dpv/modules/context-en.html
@@ -408,7 +408,7 @@
 </ul>
   </li>
   <li>
-    <strong>dpv:Justification</strong>: A form of documentation providing reaosns, explanations, or justifications 
+    <strong>dpv:Justification</strong>: A form of documentation providing reasons, explanations, or justifications 
       <small><a href="https://w3id.org/dpv#Justification">go to full definition</a></small>
       
   </li>
@@ -1565,7 +1565,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/context-owl.html
+++ b/dpv/modules/context-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/context-owl.jsonld
+++ b/dpv/modules/context-owl.jsonld
@@ -1291,7 +1291,7 @@
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "A form of documentation providing reaosns, explanations, or justifications"
+        "@value": "A form of documentation providing reasons, explanations, or justifications"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [

--- a/dpv/modules/context-owl.n3
+++ b/dpv/modules/context-owl.n3
@@ -110,7 +110,7 @@ dpv-owl:Justification a rdfs:Class,
     rdfs:isDefinedBy dpv-owl: ;
     rdfs:subClassOf dpv-owl:Context ;
     sw:term_status "accepted"@en ;
-    skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en ;
+    skos:definition "A form of documentation providing reasons, explanations, or justifications"@en ;
     skos:prefLabel "Justification"@en .
 
 dpv-owl:Necessity a rdfs:Class,

--- a/dpv/modules/context-owl.omn
+++ b/dpv/modules/context-owl.omn
@@ -195,7 +195,7 @@ Class: <https://w3id.org/dpv#Justification>
 
     Annotations: 
         rdfs:isDefinedBy <https://w3id.org/dpv#>,
-        skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en,
+        skos:definition "A form of documentation providing reasons, explanations, or justifications"@en,
         skos:prefLabel "Justification"@en
     
     SubClassOf: 

--- a/dpv/modules/context-owl.owl
+++ b/dpv/modules/context-owl.owl
@@ -407,7 +407,7 @@
     <skos:prefLabel xml:lang="en">Justification</skos:prefLabel>
     <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-06-15</dct:created>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/dpv/owl#"/>
-    <skos:definition xml:lang="en">A form of documentation providing reaosns, explanations, or justifications</skos:definition>
+    <skos:definition xml:lang="en">A form of documentation providing reasons, explanations, or justifications</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/dpv/owl#Context"/>
   </rdf:Description>
 </rdf:RDF>

--- a/dpv/modules/context-owl.ttl
+++ b/dpv/modules/context-owl.ttl
@@ -110,7 +110,7 @@ dpv-owl:Justification a rdfs:Class,
     rdfs:isDefinedBy dpv-owl: ;
     rdfs:subClassOf dpv-owl:Context ;
     sw:term_status "accepted"@en ;
-    skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en ;
+    skos:definition "A form of documentation providing reasons, explanations, or justifications"@en ;
     skos:prefLabel "Justification"@en .
 
 dpv-owl:Necessity a rdfs:Class,

--- a/dpv/modules/context.html
+++ b/dpv/modules/context.html
@@ -408,7 +408,7 @@
 </ul>
   </li>
   <li>
-    <strong>dpv:Justification</strong>: A form of documentation providing reaosns, explanations, or justifications 
+    <strong>dpv:Justification</strong>: A form of documentation providing reasons, explanations, or justifications 
       <small><a href="https://w3id.org/dpv#Justification">go to full definition</a></small>
       
   </li>
@@ -1565,7 +1565,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/context.jsonld
+++ b/dpv/modules/context.jsonld
@@ -1787,7 +1787,7 @@
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "A form of documentation providing reaosns, explanations, or justifications"
+        "@value": "A form of documentation providing reasons, explanations, or justifications"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [

--- a/dpv/modules/context.n3
+++ b/dpv/modules/context.n3
@@ -123,7 +123,7 @@ dpv:Justification a rdfs:Class,
     rdfs:subClassOf dpv:Context ;
     sw:term_status "accepted"@en ;
     skos:broader dpv:Context ;
-    skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en ;
+    skos:definition "A form of documentation providing reasons, explanations, or justifications"@en ;
     skos:inScheme dpv:context-classes ;
     skos:prefLabel "Justification"@en .
 

--- a/dpv/modules/context.rdf
+++ b/dpv/modules/context.rdf
@@ -366,7 +366,7 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
     <skos:prefLabel xml:lang="en">Justification</skos:prefLabel>
-    <skos:definition xml:lang="en">A form of documentation providing reaosns, explanations, or justifications</skos:definition>
+    <skos:definition xml:lang="en">A form of documentation providing reasons, explanations, or justifications</skos:definition>
     <rdfs:subClassOf rdf:resource="https://w3id.org/dpv#Context"/>
     <skos:broader rdf:resource="https://w3id.org/dpv#Context"/>
     <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-06-15</dct:created>

--- a/dpv/modules/context.ttl
+++ b/dpv/modules/context.ttl
@@ -123,7 +123,7 @@ dpv:Justification a rdfs:Class,
     rdfs:subClassOf dpv:Context ;
     sw:term_status "accepted"@en ;
     skos:broader dpv:Context ;
-    skos:definition "A form of documentation providing reaosns, explanations, or justifications"@en ;
+    skos:definition "A form of documentation providing reasons, explanations, or justifications"@en ;
     skos:inScheme dpv:context-classes ;
     skos:prefLabel "Justification"@en .
 

--- a/dpv/modules/entities-owl.html
+++ b/dpv/modules/entities-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/legal_basis-owl.html
+++ b/dpv/modules/legal_basis-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/personal_data-owl.html
+++ b/dpv/modules/personal_data-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/processing-owl.html
+++ b/dpv/modules/processing-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/purposes-owl.html
+++ b/dpv/modules/purposes-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/rights-owl.html
+++ b/dpv/modules/rights-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/risk-owl.html
+++ b/dpv/modules/risk-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        

--- a/dpv/modules/rules-owl.html
+++ b/dpv/modules/rules-owl.html
@@ -23781,7 +23781,7 @@
 
 <tr>
           <th>Definition</th>
-          <td><i>A form of documentation providing reaosns, explanations, or justifications</i></td>
+          <td><i>A form of documentation providing reasons, explanations, or justifications</i></td>
         </tr>        
        
        


### PR DESCRIPTION
Fix typo in dpv:Justification
- "reaosns" -> "reasons"