### PR TITLE
fix typos in justifications and EU DGA extensions

### DIFF
--- a/code/jinja2_resources/template_justifications.jinja2
+++ b/code/jinja2_resources/template_justifications.jinja2
@@ -59,24 +59,24 @@
 </head>
 <body>
   <section id="abstract">
-    <p>Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
+    <p>The Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
     {{ sotd() }}
     {{ dpv_document_family(document='justifications-spec') }}
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
+    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support the expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
     <p>Justifications can be found in regulations as exceptions to obligations - for example in GDPR Article 12-5 the justification "requests ... are manifestly unfounded or excessive" is mentioned. Justifications can also be identified through practical applications and use-cases, such as where organisations and data subjects commonly need to state reasons or explanations. As such, the DPVCG strives to provide a rich and comprehensive taxonomy of justifications and welcomes contributions for the same.</p>
     <aside class="example" title="Associating justifications with right exercise non-fulfilment">
       <p>The following example represents a notice outlining a failure to complete a GDPR Data Portability request due to identity verification failure.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dct:dateSubmitted "2024-01-01"^^xsd:date ;
   dct:publisher ex:SomeController ;
   dpv:hasRight eu-gdpr:A20 ;
   dpv:hasJustification justifications:IdentityVerificationFailure .</code></pre>
     </aside>
-    <aside class="note" title="Associating justifications with regulations e.g. GDPR">
-      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g. [[EU-GDPR]] extension for [[GDPR]].</p>
+    <aside class="note" title="Associating justifications with regulations, e.g., GDPR">
+      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g., [[EU-GDPR]] extension for [[GDPR]].</p>
     </aside>
   </section>
 
@@ -84,15 +84,15 @@
     <h2>Justification Types</h2>
     <p>Justifications are broadly categorised as:</p>
     <ul>
-      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or isn't applicable</li>
+      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or is not applicable</li>
       <li><code>NonFulfilmentJustification</code>: Justification for not fulfilling a process or requirement or obligation</li>
       <li><code>DelayJustification</code>: Justification to delay a process</li>
       <li><code>ExerciseJustification</code>: Justification for why the process should be carried out</li>
     </ul>
     <p>This categorisation is not exact and mutually exclusive, but is provided as a convenience to organise the concepts in a comprehensible hierarchy. For example, a justification concept declared as <code>DelayJustification</code> can still be used as a <code>NonFulfilmentJustification</code> within a use-case.</p>
     <aside class="example" title="Using justifications across categories">
-      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity in fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:Process;
+      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity of fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:Process ;
   dpv:hasJustification [
     a dpv:Justification ;
     skos:broader justifications:ComplexityOfProcess ;
@@ -106,7 +106,7 @@
       <p>Situations where a particular process is not-required or applicable have justifications of type <code>NotRequiredJustification</code>.</p>
     <aside class="example" title="Expressing data breach notifications to data subjects are not required using a justification">
       <p>The justification <code>RightsFreedomsImpactUnlikely</code> represents an unlikely impact on rights and freedoms, which can be used as a justification to not provide data subjects with a notification about a data breach involving their personal data as per GDPR Article 35-3b.</p>
-      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport;
+      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport ;
   dpv:hasStatus eu-gdpr:BreachNotificationNotNeeded ;
   dpv:hasJustification justifications:RightsFreedomsImpactUnlikely .</code></pre>
     </aside>
@@ -120,7 +120,7 @@
       <p>Where a particular process cannot be fulfilled, the relevant justification or reason is expressed using the concept <code>NonFulfilmentJustification</code>.</p>
     <aside class="example" title="Expressing GDPR Right to Data Portability could not be fulfilled due to Identity Verification failure">
       <p>The following example describes a GDPR Article 20 Data Portability request not being fulfilled due to identity verification failure. The <code>dpv:RequestRequiresAction</code> concept indicates further action is required - specifically to provide identity documents.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord ;
   dpv:hasStatus dpv:RequestRequiresAction ;
   dpv:hasJustification justifications:IdentityVerificationFailure ;
   dpv:hasProcess [
@@ -136,10 +136,10 @@
 
     <section id="vocab-justifications-delay">
       <h3>Delay</h3>
-      <p>Where a particular process is delayed, the justifications are represented through concept <code>DelayJustification</code>.</p>
+      <p>Where a particular process is delayed, the justifications are represented through the concept <code>DelayJustification</code>.</p>
     <aside class="example" title="Expressing a right exercise request is delayed due to high volume of requests">
-      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests is causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dpv:hasStatus dpv:RequestActionDelayed ;
   dpv:hasJustification justifications:HighVolumeOfProcesses ;
   dpv:hasDuration "P6M" .  # ISO 8601 6 Months</code></pre>
@@ -151,9 +151,9 @@
     <section id="vocab-justifications-exercise">
       <h3>Exercise</h3>
       <p>To indicate why a particular process must be undertaken or is being requested, the justifications are represented using the concept <code>ExerciseJustification</code>.</p>
-    <aside class="example" title="Excercising the right to rectification with contesting accuracy of information as justification">
+    <aside class="example" title="Exercising the right to rectification with contesting accuracy of information as justification">
       <p>The following example shows the justification <code>ContestAccuracy</code> representing contesting the accuracy of information or process to justify why the right to rectification as per GDPR Article 16 is being exercised. The information in question is represented using <code>dpv:hasPersonalData</code>, with two processes indicating which data should be deleted and the correction.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16 ;
   dpv:hasStatus dpv:RequestInitiated ;
   dpv:hasJustification justifications:ContestAccuracy ;
   dpv:hasProcess [

--- a/code/jinja2_resources/template_legal_eu_dga.jinja2
+++ b/code/jinja2_resources/template_legal_eu_dga.jinja2
@@ -66,7 +66,7 @@
 <body>
 {% block ABSTRACT %}
   <section id="abstract">
-    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
+    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, and other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
     <p>This work was first presented in the article "<a href="https://doi.org/10.3233/SSW230015"><i>Semantics for Implementing Data Reuse and Altruism under EU's Data Governance Act</i></a>" by Beatriz Esteves, Victor Rodriguez Doncel, Harshvardhan J. Pandit, and Dave Lewis.</p>
     {{ sotd() }}
     {{ dpv_document_family(document='eu-dga-spec') }}
@@ -75,7 +75,7 @@
 {% block INTRODUCTION %}
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>This extension provides concepts relevant for the implementation of [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations such as [[GDPR]] and respect rights and freedoms.</p>
+    <p>This extension provides concepts relevant for the implementation of EU's [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations, such as [[GDPR]], and respect rights and freedoms.</p>
     <aside class="note" title="Extending the DGA vocabulary">
       <p>The DPVCG welcomes contributions and discussion on how this extension can be further enhanced and expanded to realise the goals of the DGA.</p>
     </aside>
@@ -86,7 +86,7 @@
       <li><a href="#vocab-legal-rights">Rights</a></li>
       <li><a href="#vocab-services">Services</a></li>
       <li><a href="#vocab-registers">Registers Of Entities</a></li>
-      <li><a href="#vocab-toms">Tech/org Measures</a></li>
+      <li><a href="#vocab-toms">Tech/Org Measures</a></li>
     </ul>
   </section>
 {% endblock INTRODUCTION %}
@@ -94,7 +94,7 @@
 
     <section id="vocab-entities">
     <h2>Entities</h2>
-    <p>Entities in the DGA are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
+    <p>Entities in the [[DGA]] are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
     <aside class="note" title="Associating entities in context">
       <p>We are discussing the addition of specific relations to associate entities with processes, e.g. <code>hasDataHolder</code> based on the evolving DGA implementations and authoritative guidance.</p>
     </aside>
@@ -104,27 +104,27 @@
 
     <section id="vocab-legal-basis">
     <h2>Legal Bases</h2>
-    <p>Legal bases in the DGA relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
+    <p>Legal bases in the [[DGA]] relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
     {{ list_hierarchy(modules['legal_basis']['classes']) }}
     </section>
 
   <section id="vocab-legal-rights">
     <h2>Rights under DGA</h2>
-    <p>DGA provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
+    <p>The [[DGA]] provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
 
     {{ list_hierarchy(modules['legal_rights']['classes']) }}
   </section>
 
   <section id="vocab-services">
     <h2>Services</h2>
-    <p>[[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
+    <p>The [[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
     
     {{ list_hierarchy(modules['services']['classes']) }}
   </section>
 
   <section id="vocab-registers">
     <h2>Registers</h2>
-    <p>[[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
+    <p>The [[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
     
     {{ list_hierarchy(modules['registers']['classes']) }}
   </section>

--- a/justifications/index-en.html
+++ b/justifications/index-en.html
@@ -350,7 +350,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
+    <p>The Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
     <section id="sotd">
     <p style="color: red; font-weight: bold;">The DPVCG is currently updating the specifications to v2. This document is a draft and may change as part of this process.</p>
     <p><strong>Contributing:</strong> The DPVCG welcomes participation to improve the DPV and associated resources, including expansion or refinement of concepts, requesting information and applications, and addressing open issues. <a href="https://github.com/w3c/dpv/blob/master/contributing.md">See contributing page</a> for further information.</p>
@@ -367,18 +367,18 @@
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
+    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support the expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
     <p>Justifications can be found in regulations as exceptions to obligations - for example in GDPR Article 12-5 the justification "requests ... are manifestly unfounded or excessive" is mentioned. Justifications can also be identified through practical applications and use-cases, such as where organisations and data subjects commonly need to state reasons or explanations. As such, the DPVCG strives to provide a rich and comprehensive taxonomy of justifications and welcomes contributions for the same.</p>
     <aside class="example" title="Associating justifications with right exercise non-fulfilment">
       <p>The following example represents a notice outlining a failure to complete a GDPR Data Portability request due to identity verification failure.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dct:dateSubmitted "2024-01-01"^^xsd:date ;
   dct:publisher ex:SomeController ;
   dpv:hasRight eu-gdpr:A20 ;
   dpv:hasJustification justifications:IdentityVerificationFailure .</code></pre>
     </aside>
-    <aside class="note" title="Associating justifications with regulations e.g. GDPR">
-      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g. [[EU-GDPR]] extension for [[GDPR]].</p>
+    <aside class="note" title="Associating justifications with regulations, e.g., GDPR">
+      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g., [[EU-GDPR]] extension for [[GDPR]].</p>
     </aside>
   </section>
 
@@ -386,15 +386,15 @@
     <h2>Justification Types</h2>
     <p>Justifications are broadly categorised as:</p>
     <ul>
-      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or isn't applicable</li>
+      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or is not applicable</li>
       <li><code>NonFulfilmentJustification</code>: Justification for not fulfilling a process or requirement or obligation</li>
       <li><code>DelayJustification</code>: Justification to delay a process</li>
       <li><code>ExerciseJustification</code>: Justification for why the process should be carried out</li>
     </ul>
     <p>This categorisation is not exact and mutually exclusive, but is provided as a convenience to organise the concepts in a comprehensible hierarchy. For example, a justification concept declared as <code>DelayJustification</code> can still be used as a <code>NonFulfilmentJustification</code> within a use-case.</p>
     <aside class="example" title="Using justifications across categories">
-      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity in fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:Process;
+      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity of fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:Process ;
   dpv:hasJustification [
     a dpv:Justification ;
     skos:broader justifications:ComplexityOfProcess ;
@@ -408,7 +408,7 @@
       <p>Situations where a particular process is not-required or applicable have justifications of type <code>NotRequiredJustification</code>.</p>
     <aside class="example" title="Expressing data breach notifications to data subjects are not required using a justification">
       <p>The justification <code>RightsFreedomsImpactUnlikely</code> represents an unlikely impact on rights and freedoms, which can be used as a justification to not provide data subjects with a notification about a data breach involving their personal data as per GDPR Article 35-3b.</p>
-      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport;
+      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport ;
   dpv:hasStatus eu-gdpr:BreachNotificationNotNeeded ;
   dpv:hasJustification justifications:RightsFreedomsImpactUnlikely .</code></pre>
     </aside>
@@ -439,7 +439,7 @@
       <p>Where a particular process cannot be fulfilled, the relevant justification or reason is expressed using the concept <code>NonFulfilmentJustification</code>.</p>
     <aside class="example" title="Expressing GDPR Right to Data Portability could not be fulfilled due to Identity Verification failure">
       <p>The following example describes a GDPR Article 20 Data Portability request not being fulfilled due to identity verification failure. The <code>dpv:RequestRequiresAction</code> concept indicates further action is required - specifically to provide identity documents.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord ;
   dpv:hasStatus dpv:RequestRequiresAction ;
   dpv:hasJustification justifications:IdentityVerificationFailure ;
   dpv:hasProcess [
@@ -742,10 +742,10 @@
 
     <section id="vocab-justifications-delay">
       <h3>Delay</h3>
-      <p>Where a particular process is delayed, the justifications are represented through concept <code>DelayJustification</code>.</p>
+      <p>Where a particular process is delayed, the justifications are represented through the concept <code>DelayJustification</code>.</p>
     <aside class="example" title="Expressing a right exercise request is delayed due to high volume of requests">
-      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests is causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dpv:hasStatus dpv:RequestActionDelayed ;
   dpv:hasJustification justifications:HighVolumeOfProcesses ;
   dpv:hasDuration "P6M" .  # ISO 8601 6 Months</code></pre>
@@ -784,9 +784,9 @@
     <section id="vocab-justifications-exercise">
       <h3>Exercise</h3>
       <p>To indicate why a particular process must be undertaken or is being requested, the justifications are represented using the concept <code>ExerciseJustification</code>.</p>
-    <aside class="example" title="Excercising the right to rectification with contesting accuracy of information as justification">
+    <aside class="example" title="Exercising the right to rectification with contesting accuracy of information as justification">
       <p>The following example shows the justification <code>ContestAccuracy</code> representing contesting the accuracy of information or process to justify why the right to rectification as per GDPR Article 16 is being exercised. The information in question is represented using <code>dpv:hasPersonalData</code>, with two processes indicating which data should be deleted and the correction.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16 ;
   dpv:hasStatus dpv:RequestInitiated ;
   dpv:hasJustification justifications:ContestAccuracy ;
   dpv:hasProcess [

--- a/justifications/index.html
+++ b/justifications/index.html
@@ -350,7 +350,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
+    <p>The Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
     <section id="sotd">
     <p style="color: red; font-weight: bold;">The DPVCG is currently updating the specifications to v2. This document is a draft and may change as part of this process.</p>
     <p><strong>Contributing:</strong> The DPVCG welcomes participation to improve the DPV and associated resources, including expansion or refinement of concepts, requesting information and applications, and addressing open issues. <a href="https://github.com/w3c/dpv/blob/master/contributing.md">See contributing page</a> for further information.</p>
@@ -367,18 +367,18 @@
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
+    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support the expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
     <p>Justifications can be found in regulations as exceptions to obligations - for example in GDPR Article 12-5 the justification "requests ... are manifestly unfounded or excessive" is mentioned. Justifications can also be identified through practical applications and use-cases, such as where organisations and data subjects commonly need to state reasons or explanations. As such, the DPVCG strives to provide a rich and comprehensive taxonomy of justifications and welcomes contributions for the same.</p>
     <aside class="example" title="Associating justifications with right exercise non-fulfilment">
       <p>The following example represents a notice outlining a failure to complete a GDPR Data Portability request due to identity verification failure.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dct:dateSubmitted "2024-01-01"^^xsd:date ;
   dct:publisher ex:SomeController ;
   dpv:hasRight eu-gdpr:A20 ;
   dpv:hasJustification justifications:IdentityVerificationFailure .</code></pre>
     </aside>
-    <aside class="note" title="Associating justifications with regulations e.g. GDPR">
-      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g. [[EU-GDPR]] extension for [[GDPR]].</p>
+    <aside class="note" title="Associating justifications with regulations, e.g., GDPR">
+      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g., [[EU-GDPR]] extension for [[GDPR]].</p>
     </aside>
   </section>
 
@@ -386,15 +386,15 @@
     <h2>Justification Types</h2>
     <p>Justifications are broadly categorised as:</p>
     <ul>
-      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or isn't applicable</li>
+      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or is not applicable</li>
       <li><code>NonFulfilmentJustification</code>: Justification for not fulfilling a process or requirement or obligation</li>
       <li><code>DelayJustification</code>: Justification to delay a process</li>
       <li><code>ExerciseJustification</code>: Justification for why the process should be carried out</li>
     </ul>
     <p>This categorisation is not exact and mutually exclusive, but is provided as a convenience to organise the concepts in a comprehensible hierarchy. For example, a justification concept declared as <code>DelayJustification</code> can still be used as a <code>NonFulfilmentJustification</code> within a use-case.</p>
     <aside class="example" title="Using justifications across categories">
-      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity in fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:Process;
+      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity of fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:Process ;
   dpv:hasJustification [
     a dpv:Justification ;
     skos:broader justifications:ComplexityOfProcess ;
@@ -408,7 +408,7 @@
       <p>Situations where a particular process is not-required or applicable have justifications of type <code>NotRequiredJustification</code>.</p>
     <aside class="example" title="Expressing data breach notifications to data subjects are not required using a justification">
       <p>The justification <code>RightsFreedomsImpactUnlikely</code> represents an unlikely impact on rights and freedoms, which can be used as a justification to not provide data subjects with a notification about a data breach involving their personal data as per GDPR Article 35-3b.</p>
-      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport;
+      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport ;
   dpv:hasStatus eu-gdpr:BreachNotificationNotNeeded ;
   dpv:hasJustification justifications:RightsFreedomsImpactUnlikely .</code></pre>
     </aside>
@@ -439,7 +439,7 @@
       <p>Where a particular process cannot be fulfilled, the relevant justification or reason is expressed using the concept <code>NonFulfilmentJustification</code>.</p>
     <aside class="example" title="Expressing GDPR Right to Data Portability could not be fulfilled due to Identity Verification failure">
       <p>The following example describes a GDPR Article 20 Data Portability request not being fulfilled due to identity verification failure. The <code>dpv:RequestRequiresAction</code> concept indicates further action is required - specifically to provide identity documents.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord ;
   dpv:hasStatus dpv:RequestRequiresAction ;
   dpv:hasJustification justifications:IdentityVerificationFailure ;
   dpv:hasProcess [
@@ -742,10 +742,10 @@
 
     <section id="vocab-justifications-delay">
       <h3>Delay</h3>
-      <p>Where a particular process is delayed, the justifications are represented through concept <code>DelayJustification</code>.</p>
+      <p>Where a particular process is delayed, the justifications are represented through the concept <code>DelayJustification</code>.</p>
     <aside class="example" title="Expressing a right exercise request is delayed due to high volume of requests">
-      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests is causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dpv:hasStatus dpv:RequestActionDelayed ;
   dpv:hasJustification justifications:HighVolumeOfProcesses ;
   dpv:hasDuration "P6M" .  # ISO 8601 6 Months</code></pre>
@@ -784,9 +784,9 @@
     <section id="vocab-justifications-exercise">
       <h3>Exercise</h3>
       <p>To indicate why a particular process must be undertaken or is being requested, the justifications are represented using the concept <code>ExerciseJustification</code>.</p>
-    <aside class="example" title="Excercising the right to rectification with contesting accuracy of information as justification">
+    <aside class="example" title="Exercising the right to rectification with contesting accuracy of information as justification">
       <p>The following example shows the justification <code>ContestAccuracy</code> representing contesting the accuracy of information or process to justify why the right to rectification as per GDPR Article 16 is being exercised. The information in question is represented using <code>dpv:hasPersonalData</code>, with two processes indicating which data should be deleted and the correction.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16 ;
   dpv:hasStatus dpv:RequestInitiated ;
   dpv:hasJustification justifications:ContestAccuracy ;
   dpv:hasProcess [

--- a/justifications/justifications-en.html
+++ b/justifications/justifications-en.html
@@ -350,7 +350,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
+    <p>The Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
     <section id="sotd">
     <p style="color: red; font-weight: bold;">The DPVCG is currently updating the specifications to v2. This document is a draft and may change as part of this process.</p>
     <p><strong>Contributing:</strong> The DPVCG welcomes participation to improve the DPV and associated resources, including expansion or refinement of concepts, requesting information and applications, and addressing open issues. <a href="https://github.com/w3c/dpv/blob/master/contributing.md">See contributing page</a> for further information.</p>
@@ -367,18 +367,18 @@
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
+    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support the expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
     <p>Justifications can be found in regulations as exceptions to obligations - for example in GDPR Article 12-5 the justification "requests ... are manifestly unfounded or excessive" is mentioned. Justifications can also be identified through practical applications and use-cases, such as where organisations and data subjects commonly need to state reasons or explanations. As such, the DPVCG strives to provide a rich and comprehensive taxonomy of justifications and welcomes contributions for the same.</p>
     <aside class="example" title="Associating justifications with right exercise non-fulfilment">
       <p>The following example represents a notice outlining a failure to complete a GDPR Data Portability request due to identity verification failure.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dct:dateSubmitted "2024-01-01"^^xsd:date ;
   dct:publisher ex:SomeController ;
   dpv:hasRight eu-gdpr:A20 ;
   dpv:hasJustification justifications:IdentityVerificationFailure .</code></pre>
     </aside>
-    <aside class="note" title="Associating justifications with regulations e.g. GDPR">
-      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g. [[EU-GDPR]] extension for [[GDPR]].</p>
+    <aside class="note" title="Associating justifications with regulations, e.g., GDPR">
+      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g., [[EU-GDPR]] extension for [[GDPR]].</p>
     </aside>
   </section>
 
@@ -386,15 +386,15 @@
     <h2>Justification Types</h2>
     <p>Justifications are broadly categorised as:</p>
     <ul>
-      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or isn't applicable</li>
+      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or is not applicable</li>
       <li><code>NonFulfilmentJustification</code>: Justification for not fulfilling a process or requirement or obligation</li>
       <li><code>DelayJustification</code>: Justification to delay a process</li>
       <li><code>ExerciseJustification</code>: Justification for why the process should be carried out</li>
     </ul>
     <p>This categorisation is not exact and mutually exclusive, but is provided as a convenience to organise the concepts in a comprehensible hierarchy. For example, a justification concept declared as <code>DelayJustification</code> can still be used as a <code>NonFulfilmentJustification</code> within a use-case.</p>
     <aside class="example" title="Using justifications across categories">
-      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity in fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:Process;
+      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity of fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:Process ;
   dpv:hasJustification [
     a dpv:Justification ;
     skos:broader justifications:ComplexityOfProcess ;
@@ -408,7 +408,7 @@
       <p>Situations where a particular process is not-required or applicable have justifications of type <code>NotRequiredJustification</code>.</p>
     <aside class="example" title="Expressing data breach notifications to data subjects are not required using a justification">
       <p>The justification <code>RightsFreedomsImpactUnlikely</code> represents an unlikely impact on rights and freedoms, which can be used as a justification to not provide data subjects with a notification about a data breach involving their personal data as per GDPR Article 35-3b.</p>
-      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport;
+      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport ;
   dpv:hasStatus eu-gdpr:BreachNotificationNotNeeded ;
   dpv:hasJustification justifications:RightsFreedomsImpactUnlikely .</code></pre>
     </aside>
@@ -439,7 +439,7 @@
       <p>Where a particular process cannot be fulfilled, the relevant justification or reason is expressed using the concept <code>NonFulfilmentJustification</code>.</p>
     <aside class="example" title="Expressing GDPR Right to Data Portability could not be fulfilled due to Identity Verification failure">
       <p>The following example describes a GDPR Article 20 Data Portability request not being fulfilled due to identity verification failure. The <code>dpv:RequestRequiresAction</code> concept indicates further action is required - specifically to provide identity documents.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord ;
   dpv:hasStatus dpv:RequestRequiresAction ;
   dpv:hasJustification justifications:IdentityVerificationFailure ;
   dpv:hasProcess [
@@ -742,10 +742,10 @@
 
     <section id="vocab-justifications-delay">
       <h3>Delay</h3>
-      <p>Where a particular process is delayed, the justifications are represented through concept <code>DelayJustification</code>.</p>
+      <p>Where a particular process is delayed, the justifications are represented through the concept <code>DelayJustification</code>.</p>
     <aside class="example" title="Expressing a right exercise request is delayed due to high volume of requests">
-      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests is causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dpv:hasStatus dpv:RequestActionDelayed ;
   dpv:hasJustification justifications:HighVolumeOfProcesses ;
   dpv:hasDuration "P6M" .  # ISO 8601 6 Months</code></pre>
@@ -784,9 +784,9 @@
     <section id="vocab-justifications-exercise">
       <h3>Exercise</h3>
       <p>To indicate why a particular process must be undertaken or is being requested, the justifications are represented using the concept <code>ExerciseJustification</code>.</p>
-    <aside class="example" title="Excercising the right to rectification with contesting accuracy of information as justification">
+    <aside class="example" title="Exercising the right to rectification with contesting accuracy of information as justification">
       <p>The following example shows the justification <code>ContestAccuracy</code> representing contesting the accuracy of information or process to justify why the right to rectification as per GDPR Article 16 is being exercised. The information in question is represented using <code>dpv:hasPersonalData</code>, with two processes indicating which data should be deleted and the correction.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16 ;
   dpv:hasStatus dpv:RequestInitiated ;
   dpv:hasJustification justifications:ContestAccuracy ;
   dpv:hasProcess [

--- a/justifications/justifications.html
+++ b/justifications/justifications.html
@@ -350,7 +350,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
+    <p>The Justification extension provides a taxonomy extending the [[[DPV]]] concept <code>Justification</code> to enable representing specific justifications associated with non-fulfilment, non-requirement, delays, and exercising reasons involved in processes. The namespace for terms in justifications is <a href="http://www.w3id.org/dpv/justifications#"><code>https://www.w3id.org/dpv/justifications#</code></a>, the suggested prefix  is <code>justifications</code>, and the justifications vocabulary and its documentation is available on <a href="https://github.com/w3c/dpv">GitHub</a>.</p>
     <section id="sotd">
     <p style="color: red; font-weight: bold;">The DPVCG is currently updating the specifications to v2. This document is a draft and may change as part of this process.</p>
     <p><strong>Contributing:</strong> The DPVCG welcomes participation to improve the DPV and associated resources, including expansion or refinement of concepts, requesting information and applications, and addressing open issues. <a href="https://github.com/w3c/dpv/blob/master/contributing.md">See contributing page</a> for further information.</p>
@@ -367,18 +367,18 @@
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
+    <p>DPV provides the concept <a href="https://w3id.org/dpv#Justification"><code>Justification</code></a> and relation <a href="https://w3id.org/dpv#hasJustification"><code>hasJustification</code></a> to provide reasons or explanations in specific contexts. For example, where a right could not be fulfilled due to the identity of the individual not being established or where a request was deemed as being too excessive and burdensome to undertake. Justifications also represent reasons why a process must be undertaken, for example why a particular objection is being made or why a specific activity is asked to be undertaken. To support the expression of such specific justifications, this extension provides concepts extending <code>dpv:Justification</code>.</p>
     <p>Justifications can be found in regulations as exceptions to obligations - for example in GDPR Article 12-5 the justification "requests ... are manifestly unfounded or excessive" is mentioned. Justifications can also be identified through practical applications and use-cases, such as where organisations and data subjects commonly need to state reasons or explanations. As such, the DPVCG strives to provide a rich and comprehensive taxonomy of justifications and welcomes contributions for the same.</p>
     <aside class="example" title="Associating justifications with right exercise non-fulfilment">
       <p>The following example represents a notice outlining a failure to complete a GDPR Data Portability request due to identity verification failure.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dct:dateSubmitted "2024-01-01"^^xsd:date ;
   dct:publisher ex:SomeController ;
   dpv:hasRight eu-gdpr:A20 ;
   dpv:hasJustification justifications:IdentityVerificationFailure .</code></pre>
     </aside>
-    <aside class="note" title="Associating justifications with regulations e.g. GDPR">
-      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g. [[EU-GDPR]] extension for [[GDPR]].</p>
+    <aside class="note" title="Associating justifications with regulations, e.g., GDPR">
+      <p>This extension does not provide any association or indication of the use of justifications towards regulatory requirements, nor provide knowledge of where justifications can be used within specific regulatory obligations. Such associations and knowledge should be provided within the respective extensions for that regulation, e.g., [[EU-GDPR]] extension for [[GDPR]].</p>
     </aside>
   </section>
 
@@ -386,15 +386,15 @@
     <h2>Justification Types</h2>
     <p>Justifications are broadly categorised as:</p>
     <ul>
-      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or isn't applicable</li>
+      <li><code>NotRequiredJustification</code>: Justification to reject or not complete a process as it is not required or is not applicable</li>
       <li><code>NonFulfilmentJustification</code>: Justification for not fulfilling a process or requirement or obligation</li>
       <li><code>DelayJustification</code>: Justification to delay a process</li>
       <li><code>ExerciseJustification</code>: Justification for why the process should be carried out</li>
     </ul>
     <p>This categorisation is not exact and mutually exclusive, but is provided as a convenience to organise the concepts in a comprehensible hierarchy. For example, a justification concept declared as <code>DelayJustification</code> can still be used as a <code>NonFulfilmentJustification</code> within a use-case.</p>
     <aside class="example" title="Using justifications across categories">
-      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity in fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:Process;
+      <p>The justification concept <code>ComplexityOfProcess</code> represents a reason to delay a process due to the complexity of fulfilling it. To instead use it as a justification for not fulfilling the process, we create a new justification that combines the complexity of process and non-fulfilment categories.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:Process ;
   dpv:hasJustification [
     a dpv:Justification ;
     skos:broader justifications:ComplexityOfProcess ;
@@ -408,7 +408,7 @@
       <p>Situations where a particular process is not-required or applicable have justifications of type <code>NotRequiredJustification</code>.</p>
     <aside class="example" title="Expressing data breach notifications to data subjects are not required using a justification">
       <p>The justification <code>RightsFreedomsImpactUnlikely</code> represents an unlikely impact on rights and freedoms, which can be used as a justification to not provide data subjects with a notification about a data breach involving their personal data as per GDPR Article 35-3b.</p>
-      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport;
+      <pre class="nohighlight"><code>ex:PDH a risk:DataBreachReport ;
   dpv:hasStatus eu-gdpr:BreachNotificationNotNeeded ;
   dpv:hasJustification justifications:RightsFreedomsImpactUnlikely .</code></pre>
     </aside>
@@ -439,7 +439,7 @@
       <p>Where a particular process cannot be fulfilled, the relevant justification or reason is expressed using the concept <code>NonFulfilmentJustification</code>.</p>
     <aside class="example" title="Expressing GDPR Right to Data Portability could not be fulfilled due to Identity Verification failure">
       <p>The following example describes a GDPR Article 20 Data Portability request not being fulfilled due to identity verification failure. The <code>dpv:RequestRequiresAction</code> concept indicates further action is required - specifically to provide identity documents.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseRecord ;
   dpv:hasStatus dpv:RequestRequiresAction ;
   dpv:hasJustification justifications:IdentityVerificationFailure ;
   dpv:hasProcess [
@@ -742,10 +742,10 @@
 
     <section id="vocab-justifications-delay">
       <h3>Delay</h3>
-      <p>Where a particular process is delayed, the justifications are represented through concept <code>DelayJustification</code>.</p>
+      <p>Where a particular process is delayed, the justifications are represented through the concept <code>DelayJustification</code>.</p>
     <aside class="example" title="Expressing a right exercise request is delayed due to high volume of requests">
-      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests is causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice;
+      <p>The following example uses the justification <code>HighVolumeOfProcesses</code> to represent a high volume of similar processes or requests causing a delay in fulfilling the rights request. The concept <code>dpv:hasDuration</code> is used to indicate the duration of the delay.</p>
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightNonFulfilmentNotice ;
   dpv:hasStatus dpv:RequestActionDelayed ;
   dpv:hasJustification justifications:HighVolumeOfProcesses ;
   dpv:hasDuration "P6M" .  # ISO 8601 6 Months</code></pre>
@@ -784,9 +784,9 @@
     <section id="vocab-justifications-exercise">
       <h3>Exercise</h3>
       <p>To indicate why a particular process must be undertaken or is being requested, the justifications are represented using the concept <code>ExerciseJustification</code>.</p>
-    <aside class="example" title="Excercising the right to rectification with contesting accuracy of information as justification">
+    <aside class="example" title="Exercising the right to rectification with contesting accuracy of information as justification">
       <p>The following example shows the justification <code>ContestAccuracy</code> representing contesting the accuracy of information or process to justify why the right to rectification as per GDPR Article 16 is being exercised. The information in question is represented using <code>dpv:hasPersonalData</code>, with two processes indicating which data should be deleted and the correction.</p>
-      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16;
+      <pre class="nohighlight"><code>ex:PDH a dpv:RightExerciseActivity, eu-gdpr:A16 ;
   dpv:hasStatus dpv:RequestInitiated ;
   dpv:hasJustification justifications:ContestAccuracy ;
   dpv:hasProcess [

--- a/legal/eu/dga/eu-dga-en.html
+++ b/legal/eu/dga/eu-dga-en.html
@@ -350,7 +350,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
+    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, and other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
     <p>This work was first presented in the article "<a href="https://doi.org/10.3233/SSW230015"><i>Semantics for Implementing Data Reuse and Altruism under EU's Data Governance Act</i></a>" by Beatriz Esteves, Victor Rodriguez Doncel, Harshvardhan J. Pandit, and Dave Lewis.</p>
     <section id="sotd">
     <p style="color: red; font-weight: bold;">The DPVCG is currently updating the specifications to v2. This document is a draft and may change as part of this process.</p>
@@ -368,7 +368,7 @@
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>This extension provides concepts relevant for the implementation of [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations such as [[GDPR]] and respect rights and freedoms.</p>
+    <p>This extension provides concepts relevant for the implementation of EU's [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations, such as [[GDPR]], and respect rights and freedoms.</p>
     <aside class="note" title="Extending the DGA vocabulary">
       <p>The DPVCG welcomes contributions and discussion on how this extension can be further enhanced and expanded to realise the goals of the DGA.</p>
     </aside>
@@ -379,13 +379,13 @@
       <li><a href="#vocab-legal-rights">Rights</a></li>
       <li><a href="#vocab-services">Services</a></li>
       <li><a href="#vocab-registers">Registers Of Entities</a></li>
-      <li><a href="#vocab-toms">Tech/org Measures</a></li>
+      <li><a href="#vocab-toms">Tech/Org Measures</a></li>
     </ul>
   </section>
 
     <section id="vocab-entities">
     <h2>Entities</h2>
-    <p>Entities in the DGA are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
+    <p>Entities in the [[DGA]] are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
     <aside class="note" title="Associating entities in context">
       <p>We are discussing the addition of specific relations to associate entities with processes, e.g. <code>hasDataHolder</code> based on the evolving DGA implementations and authoritative guidance.</p>
     </aside>
@@ -483,7 +483,7 @@
 
     <section id="vocab-legal-basis">
     <h2>Legal Bases</h2>
-    <p>Legal bases in the DGA relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
+    <p>Legal bases in the [[DGA]] relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
     <strong>eu-dga:A12-e-Exchange-Approval</strong>: Explicit request or approval of the data subject or data holder to utilise additional specific tools for the purposes of facilitating exchange of data
@@ -525,7 +525,7 @@
 
   <section id="vocab-legal-rights">
     <h2>Rights under DGA</h2>
-    <p>DGA provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
+    <p>The [[DGA]] provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
 
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
@@ -548,7 +548,7 @@
 
   <section id="vocab-services">
     <h2>Services</h2>
-    <p>[[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
+    <p>The [[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
     
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
@@ -582,7 +582,7 @@
 
   <section id="vocab-registers">
     <h2>Registers</h2>
-    <p>[[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
+    <p>The [[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
     
     <div class="list-hierarchy"><ul class="concept-list">
   <li>

--- a/legal/eu/dga/eu-dga.html
+++ b/legal/eu/dga/eu-dga.html
@@ -350,7 +350,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
+    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, and other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
     <p>This work was first presented in the article "<a href="https://doi.org/10.3233/SSW230015"><i>Semantics for Implementing Data Reuse and Altruism under EU's Data Governance Act</i></a>" by Beatriz Esteves, Victor Rodriguez Doncel, Harshvardhan J. Pandit, and Dave Lewis.</p>
     <section id="sotd">
     <p style="color: red; font-weight: bold;">The DPVCG is currently updating the specifications to v2. This document is a draft and may change as part of this process.</p>
@@ -368,7 +368,7 @@
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>This extension provides concepts relevant for the implementation of [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations such as [[GDPR]] and respect rights and freedoms.</p>
+    <p>This extension provides concepts relevant for the implementation of EU's [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations, such as [[GDPR]], and respect rights and freedoms.</p>
     <aside class="note" title="Extending the DGA vocabulary">
       <p>The DPVCG welcomes contributions and discussion on how this extension can be further enhanced and expanded to realise the goals of the DGA.</p>
     </aside>
@@ -379,13 +379,13 @@
       <li><a href="#vocab-legal-rights">Rights</a></li>
       <li><a href="#vocab-services">Services</a></li>
       <li><a href="#vocab-registers">Registers Of Entities</a></li>
-      <li><a href="#vocab-toms">Tech/org Measures</a></li>
+      <li><a href="#vocab-toms">Tech/Org Measures</a></li>
     </ul>
   </section>
 
     <section id="vocab-entities">
     <h2>Entities</h2>
-    <p>Entities in the DGA are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
+    <p>Entities in the [[DGA]] are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
     <aside class="note" title="Associating entities in context">
       <p>We are discussing the addition of specific relations to associate entities with processes, e.g. <code>hasDataHolder</code> based on the evolving DGA implementations and authoritative guidance.</p>
     </aside>
@@ -483,7 +483,7 @@
 
     <section id="vocab-legal-basis">
     <h2>Legal Bases</h2>
-    <p>Legal bases in the DGA relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
+    <p>Legal bases in the [[DGA]] relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
     <strong>eu-dga:A12-e-Exchange-Approval</strong>: Explicit request or approval of the data subject or data holder to utilise additional specific tools for the purposes of facilitating exchange of data
@@ -525,7 +525,7 @@
 
   <section id="vocab-legal-rights">
     <h2>Rights under DGA</h2>
-    <p>DGA provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
+    <p>The [[DGA]] provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
 
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
@@ -548,7 +548,7 @@
 
   <section id="vocab-services">
     <h2>Services</h2>
-    <p>[[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
+    <p>The [[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
     
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
@@ -582,7 +582,7 @@
 
   <section id="vocab-registers">
     <h2>Registers</h2>
-    <p>[[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
+    <p>The [[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
     
     <div class="list-hierarchy"><ul class="concept-list">
   <li>

--- a/legal/eu/dga/index-en.html
+++ b/legal/eu/dga/index-en.html
@@ -350,7 +350,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
+    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, and other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
     <p>This work was first presented in the article "<a href="https://doi.org/10.3233/SSW230015"><i>Semantics for Implementing Data Reuse and Altruism under EU's Data Governance Act</i></a>" by Beatriz Esteves, Victor Rodriguez Doncel, Harshvardhan J. Pandit, and Dave Lewis.</p>
     <section id="sotd">
     <p style="color: red; font-weight: bold;">The DPVCG is currently updating the specifications to v2. This document is a draft and may change as part of this process.</p>
@@ -368,7 +368,7 @@
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>This extension provides concepts relevant for the implementation of [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations such as [[GDPR]] and respect rights and freedoms.</p>
+    <p>This extension provides concepts relevant for the implementation of EU's [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations, such as [[GDPR]], and respect rights and freedoms.</p>
     <aside class="note" title="Extending the DGA vocabulary">
       <p>The DPVCG welcomes contributions and discussion on how this extension can be further enhanced and expanded to realise the goals of the DGA.</p>
     </aside>
@@ -379,13 +379,13 @@
       <li><a href="#vocab-legal-rights">Rights</a></li>
       <li><a href="#vocab-services">Services</a></li>
       <li><a href="#vocab-registers">Registers Of Entities</a></li>
-      <li><a href="#vocab-toms">Tech/org Measures</a></li>
+      <li><a href="#vocab-toms">Tech/Org Measures</a></li>
     </ul>
   </section>
 
     <section id="vocab-entities">
     <h2>Entities</h2>
-    <p>Entities in the DGA are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
+    <p>Entities in the [[DGA]] are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
     <aside class="note" title="Associating entities in context">
       <p>We are discussing the addition of specific relations to associate entities with processes, e.g. <code>hasDataHolder</code> based on the evolving DGA implementations and authoritative guidance.</p>
     </aside>
@@ -483,7 +483,7 @@
 
     <section id="vocab-legal-basis">
     <h2>Legal Bases</h2>
-    <p>Legal bases in the DGA relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
+    <p>Legal bases in the [[DGA]] relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
     <strong>eu-dga:A12-e-Exchange-Approval</strong>: Explicit request or approval of the data subject or data holder to utilise additional specific tools for the purposes of facilitating exchange of data
@@ -525,7 +525,7 @@
 
   <section id="vocab-legal-rights">
     <h2>Rights under DGA</h2>
-    <p>DGA provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
+    <p>The [[DGA]] provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
 
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
@@ -548,7 +548,7 @@
 
   <section id="vocab-services">
     <h2>Services</h2>
-    <p>[[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
+    <p>The [[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
     
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
@@ -582,7 +582,7 @@
 
   <section id="vocab-registers">
     <h2>Registers</h2>
-    <p>[[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
+    <p>The [[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
     
     <div class="list-hierarchy"><ul class="concept-list">
   <li>

--- a/legal/eu/dga/index.html
+++ b/legal/eu/dga/index.html
@@ -350,7 +350,7 @@
 </head>
 <body>
   <section id="abstract">
-    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
+    <p>The EU-DGA extension extends the [[[DPV]]] to provide concepts such as entities, rights, and other relevant concepts based on the [[[DGA]]]. The canonical URL for the EU-DGA extension is <a href="https://w3id.org/dpv/legal/eu/dga">https://w3id.org/dpv/legal/eu/dga</a>, the namespace for EU-DGA terms is <a href="https://w3id.org/dpv/legal/eu/dga#"><code>https://w3id.org/dpv/legal/eu/dga#</code></a>, the suggested prefix is <code>eu-dga</code>, and this document along with source and releases are available at <a href="https://github.com/w3c/dpv">https://github.com/w3c/dpv</a>.</p>
     <p>This work was first presented in the article "<a href="https://doi.org/10.3233/SSW230015"><i>Semantics for Implementing Data Reuse and Altruism under EU's Data Governance Act</i></a>" by Beatriz Esteves, Victor Rodriguez Doncel, Harshvardhan J. Pandit, and Dave Lewis.</p>
     <section id="sotd">
     <p style="color: red; font-weight: bold;">The DPVCG is currently updating the specifications to v2. This document is a draft and may change as part of this process.</p>
@@ -368,7 +368,7 @@
   </section>
   <section id="motivation">
     <h2>Introduction</h2>
-    <p>This extension provides concepts relevant for the implementation of [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations such as [[GDPR]] and respect rights and freedoms.</p>
+    <p>This extension provides concepts relevant for the implementation of EU's [[[DGA]]]. The DGA promotes availability of data and encourages its sharing and reuse through novel mechanisms such as 'data intermediaries' and 'data altruism'. It also provides specific rights, and requires implementation details such as specific technical measures in order to ensure such sharing and altruistic (re-)uses of data are compliant with existing regulations, such as [[GDPR]], and respect rights and freedoms.</p>
     <aside class="note" title="Extending the DGA vocabulary">
       <p>The DPVCG welcomes contributions and discussion on how this extension can be further enhanced and expanded to realise the goals of the DGA.</p>
     </aside>
@@ -379,13 +379,13 @@
       <li><a href="#vocab-legal-rights">Rights</a></li>
       <li><a href="#vocab-services">Services</a></li>
       <li><a href="#vocab-registers">Registers Of Entities</a></li>
-      <li><a href="#vocab-toms">Tech/org Measures</a></li>
+      <li><a href="#vocab-toms">Tech/Org Measures</a></li>
     </ul>
   </section>
 
     <section id="vocab-entities">
     <h2>Entities</h2>
-    <p>Entities in the DGA are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
+    <p>Entities in the [[DGA]] are defined by extending the <code>dpv:LegalEntity</code> concept, and are associated with using the relation <code>dpv:hasEntity</code>. DGA's entities are different from 'legal roles' in GDPR's use of 'controllers' and 'processors' as the DGA entities are established with a specific role and purpose. For example, a 'Data Co-operative' is a legal entity which is established to provide the data co-operative services - namely for intermediation and exercise of rights.</p>
     <aside class="note" title="Associating entities in context">
       <p>We are discussing the addition of specific relations to associate entities with processes, e.g. <code>hasDataHolder</code> based on the evolving DGA implementations and authoritative guidance.</p>
     </aside>
@@ -483,7 +483,7 @@
 
     <section id="vocab-legal-basis">
     <h2>Legal Bases</h2>
-    <p>Legal bases in the DGA relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
+    <p>Legal bases in the [[DGA]] relate to specific activities such as processing of non-personal data ([=A2-6-Permission=]) and data transfers ([=A5-12-Adequacy-Decision=]). These are defined by extending <code>dpv:LegalBasis</code> and its subtypes, and are indicated by using the relation <code>dpv:hasLegalBasis</code>.</p>
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
     <strong>eu-dga:A12-e-Exchange-Approval</strong>: Explicit request or approval of the data subject or data holder to utilise additional specific tools for the purposes of facilitating exchange of data
@@ -525,7 +525,7 @@
 
   <section id="vocab-legal-rights">
     <h2>Rights under DGA</h2>
-    <p>DGA provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
+    <p>The [[DGA]] provides several rights to the data subject and data holders whose applicability depends on the context and nature of processing taking place. Since these rights are applicable for both data subjects and non-data subjects (data holders), they are represented by extending <code>dpv:Right</code> instead of <code>dpv:DataSubjectRight</code>. To indicate a right is applicable or available, the relation <code>dpv:hasRight</code> is used.</p>
 
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
@@ -548,7 +548,7 @@
 
   <section id="vocab-services">
     <h2>Services</h2>
-    <p>[[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
+    <p>The [[DGA]] defines and regulates several 'services', such as those for data intermediation and altruism. To represent these, the concept <code>dpv:Service</code> is extended. Services can be associated using the relation <code>dpv:hasService</code>.</p>
     
     <div class="list-hierarchy"><ul class="concept-list">
   <li>
@@ -582,7 +582,7 @@
 
   <section id="vocab-registers">
     <h2>Registers</h2>
-    <p>[[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
+    <p>The [[DGA]] requires the creation and maintenance of specific registers or registries, such as those for data altruistic organisations. These are represented by extending the concept <code>dpv:PublicRegisterOfEntities</code>. Membership of the registry can be expressed using the concept <code>dpv:hasEntity</code>, or even through use of [[SKOS]] collections.</p>
     
     <div class="list-hierarchy"><ul class="concept-list">
   <li>


### PR DESCRIPTION
I fixed typos and generated corresponding HTML.
Additionally, I'm not finding `dpv:PublicRegisterOfEntities` in the DPV HTML spec.
