### PR TITLE
Updated Affiliation (University of Koblenz-Landau -> Koblenz)

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -12,7 +12,7 @@
     "Georg P. Krog": "Signatu AS",      
     "Harshvardhan J. Pandit": "ADAPT Centre, Dublin City University",
     "Javier Fernández": "Vienna University of Economics and Business",      
-    "Julian Flake": "University of Koblenz-Landau",   
+    "Julian Flake": "University of Koblenz",   
     "Julio Fernandez": "Trinity College Dublin",
     "Luigi Sauro": "Università di Napoli Federico II",   
     "Mark Lizar": "OpenConsent/Kantara Initiative",      


### PR DESCRIPTION
Universities Koblenz and Landau are split again. Koblenz is now an independent University.