### PR TITLE
Reformat LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,29 +1,35 @@
-The documents and resources in this repository are provided by contributors under the following license.
+The documents and resources in this repository are provided by contributors under the following [W3C Software and Document license](https://www.w3.org/copyright/software-license-2023/).
+
+----
 
 This work is being provided by the copyright holders under the following license.
-License
+
+## License
 
 By obtaining and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.
 
 Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work or portions thereof, including modifications:
 
-    The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
-    Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the W3C software and document short notice should be included.
-    Notice of any changes or modifications, through a copyright statement on the new code or document such as "This software or document includes material copied from or derived from [title and URI of the W3C document]. Copyright © [$year-of-document] World Wide Web Consortium. https://www.w3.org/copyright/software-license-2023/"
+- The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+- Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the [W3C software and document short notice](https://www.w3.org/Consortium/Legal/2023/copyright-software-short-notice.html) should be included.
+- Notice of any changes or modifications, through a copyright statement on the new code or document such as "This software or document includes material copied from or derived from [title and URI of the W3C document]. Copyright © [$year-of-document] [World Wide Web Consortium](https://www.w3.org/). <https://www.w3.org/copyright/software-license-2023/>"
 
-Disclaimers
+## Disclaimers
 
 THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
 
 COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
 
 The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the work without specific, written prior permission. Title to copyright in this work will at all times remain with copyright holders.
-Versions
 
-    This version: https://www.w3.org/copyright/software-license-2023/
-    Latest version: https://www.w3.org/copyright/software-license/
-    Previous version: https://www.w3.org/copyright/software-license-2015/
+## Versions
 
-Changes since the previous document
+- This version: <https://www.w3.org/copyright/software-license-2023/>
+- Latest version: <https://www.w3.org/copyright/software-license/>
+- Previous version: <https://www.w3.org/copyright/software-license-2015/>
 
-    The 2023 version updates identification of the copyright holder.
+### Changes since the previous document
+
+- The 2023 version updates identification of the copyright holder.
+
+----

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
----
-SPDX-FileCopyrightText: 2024 Data Privacy Vocabularies and Controls Community Group and its contributors.
-SPDX-License-Identifier: W3C-20150513
----
-
 # DPVCG
 Data Privacy Vocabularies and Controls Community Group (DPVCG) repository containing
 specifications for Data Privacy Vocabulary (DPV) and its extensions, primer, and guides,

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+SPDX-FileCopyrightText: 2024 Data Privacy Vocabularies and Controls Community Group and its contributors.
+SPDX-License-Identifier: W3C-20150513
+---
+
 # DPVCG
 Data Privacy Vocabularies and Controls Community Group (DPVCG) repository containing
 specifications for Data Privacy Vocabulary (DPV) and its extensions, primer, and guides,


### PR DESCRIPTION
(Following the license discovery discussion in #195)

- Restore bullets, links, and heading formatting as appear in the license at https://www.w3.org/copyright/software-license-2023/
- Put license name at the top of the file, just before the actual license text
