### PR TITLE
Use stable ID for contributor, affiliation, and source blank nodes

### DIFF
--- a/code/vocab_funcs.py
+++ b/code/vocab_funcs.py
@@ -1,6 +1,4 @@
-from rdflib import Graph, Namespace
-from rdflib.compare import graph_diff
-from rdflib.term import Literal, URIRef, BNode
+from rdflib.term import BNode, Literal
 from vocab_management import *
 
 
@@ -239,7 +237,7 @@ def construct_source(item, data, namespace, header):
                 label = label.replace('(', '', 1)
             if url.endswith(')'):
                 url = url[::-1].replace(')', '', 1)[::-1] # reverse string
-            node = BNode()
+            node = BNode(hash_id(f'{label}{url}', 'web-', 32))
             triples.append((node, RDF.type, SCHEMA.WebPage))
             triples.append((node, SCHEMA.name, Literal(label)))
             triples.append((node, SCHEMA.url, Literal(url)))

--- a/code/vocab_funcs.py
+++ b/code/vocab_funcs.py
@@ -237,7 +237,7 @@ def construct_source(item, data, namespace, header):
                 label = label.replace('(', '', 1)
             if url.endswith(')'):
                 url = url[::-1].replace(')', '', 1)[::-1] # reverse string
-            node = BNode(hash_id(f'{label}{url}', 'web-', 32))
+            node = BNode(hash_id(f'{label}-{url}', 'web-', 16, 16))
             triples.append((node, RDF.type, SCHEMA.WebPage))
             triples.append((node, SCHEMA.name, Literal(label)))
             triples.append((node, SCHEMA.url, Literal(url)))


### PR DESCRIPTION
# Pull Request

To address issue discussed in #266, use contributor name, affiliation name, source label, source URL, and DPV version number to generate a stable ID within a DPV version. The generated IDs for blank nodes will look like:

- `_:person-316c589472c97217`
- `_:org-218d661eb0940e1a`
- `_:web-5349a9b296f3a7553e6a9132e1df2712`

(The prefix `_:` is automatically added by RDFLib as a convention for blank nodes)

These IDs are only intended to be used locally.

Will fix #266 

Update: We can also have something like this, for human readability:

- `_:person-DanielDo-316c5894`
- `_:org-Unabhäng-41451ff1`
- `_:web-GDPRArt4-1g-http-2fd893c49a38fd2a`

