### PR TITLE
Fix typos in aspell dictionary

### DIFF
--- a/code/dictionary-aspell-en.pws
+++ b/code/dictionary-aspell-en.pws
@@ -322,7 +322,7 @@ ImmigrationApplicationManagement
 ImmigrationAsylumManagement
 ImmigrationBorderControlManagement
 ImmigrationComplaintManagement
-ImmigrationDocumentVerficiation
+ImmigrationDocumentVerification
 ImmigrationEligibilityAssessment
 ImmigrationHealthRiskManagement
 ImmigrationIdentityVerification
@@ -375,7 +375,7 @@ LV
 LargeDataVolume
 LargeScaleOfDataSubjects
 LargeScaleProcessing
-LawfulnessUnkown
+LawfulnessUnknown
 LeadSupervisoryAuthority
 LeftOperand
 LegalAgreement


### PR DESCRIPTION
# Pull Request

Fix typos in the spellchecker dictionary:

- ImmigrationDocumentVerficiation -> ImmigrationDocumentVerification
- LawfulnessUnkown -> LawfulnessUnknown

This may related the typo issues in:

- #268
  which is from this template:
  https://github.com/w3c/dpv/blob/e0256e575f1b789a17d5a8559e9b099cb82ddcab/code/jinja2_resources/template_legal_eu_aiact.jinja2#L257
- And "LawfulnessUnkown" from this template:
  https://github.com/w3c/dpv/blob/e0256e575f1b789a17d5a8559e9b099cb82ddcab/code/jinja2_resources/template_dpv_context.jinja2#L156