### PR TITLE
Add InverseLocation to Locations and Memberships schemas

### DIFF
--- a/code/200_serialise_RDF.py
+++ b/code/200_serialise_RDF.py
@@ -710,7 +710,7 @@ if __name__ == '__main__':
         INFO(f'Generating outputs only for {vocabs}')
         _generate_triples(vocabs)
     else:
-        INFO(f'Generating outputs for ALL vocabulries')
+        INFO('Generating outputs for ALL vocabularies')
         _generate_triples(CSVFILES.keys())
         _generate_collations()
 

--- a/code/vocab_funcs.py
+++ b/code/vocab_funcs.py
@@ -33,7 +33,7 @@ def construct_label(item, data, namespace, header):
     triples.append((namespace[term], SKOS.prefLabel, Literal(item, lang='en')))
     return triples
 
-def contruct_definition(item, data, namespace, header):
+def construct_definition(item, data, namespace, header):
     triples = []
     term, namespace = _get_term_from_prefix_notation(data['Term'], namespace)
     annotation = SKOS.definition
@@ -342,6 +342,10 @@ def construct_un_m49(term, data, namespace, header):
     return [(namespace[data['Term']], LOC.un_m49, Literal(term))]
 
 
+def construct_inverse_location(term, data, namespace, header):
+    return [(namespace[data['Term']], LOC.inverse_location, Literal(term))]
+
+
 def construct_instance(term, data, namespace, header):
     triples = []
     for parent in term.split(','):
@@ -497,7 +501,7 @@ def construct_risk_parent_Role(term, data, namespace, header):
     return triples    
 
 
-def contruct_gdpr_right_justification(term, data, namespace, header):
+def construct_gdpr_right_justification(term, data, namespace, header):
     triples = []
     rights = [namespace[x.strip()] for x in term.split(',')]
     for right in rights:

--- a/code/vocab_schemas.py
+++ b/code/vocab_schemas.py
@@ -9,7 +9,7 @@ def get_schema(name):
 
 _common_annotations = {
     'Label': vocab_funcs.construct_label,
-    'Definition': vocab_funcs.contruct_definition,
+    'Definition': vocab_funcs.construct_definition,
     'RelatedTerms': vocab_funcs.construct_related_terms,
     'Relation': None,
     'Usage': vocab_funcs.construct_scope_note,
@@ -34,7 +34,7 @@ SCHEMA['taxonomy'] = {
     '_description': 'lorem ipsum',
     'Term': vocab_funcs.construct_class,
     'Label': vocab_funcs.construct_label,
-    'Definition': vocab_funcs.contruct_definition,
+    'Definition': vocab_funcs.construct_definition,
     'ParentTerm': None,
     'ParentType': vocab_funcs.construct_parent_taxonomy,
     'Value': vocab_funcs.construct_value,
@@ -57,7 +57,7 @@ SCHEMA['properties'] = {
     '_description': 'lorem ipsum',
     'Term': vocab_funcs.construct_property,
     'Label': vocab_funcs.construct_label,
-    'Definition': vocab_funcs.contruct_definition,
+    'Definition': vocab_funcs.construct_definition,
     'domain': vocab_funcs.construct_domain,
     'range': vocab_funcs.construct_range,
     'ParentProperty': vocab_funcs.construct_parent_property,
@@ -92,13 +92,14 @@ SCHEMA['legal_basis_rights_mapping'] = {
 SCHEMA['locations'] = {
     'Term': vocab_funcs.construct_class,
     'Label': vocab_funcs.construct_label,
-    'Definition': vocab_funcs.contruct_definition,
+    'Definition': vocab_funcs.construct_definition,
     'ParentTerm': vocab_funcs.construct_skos_broader,
     'ParentType': vocab_funcs.construct_parent_taxonomy,
     'ISO-3166-Alpha2': vocab_funcs.construct_iso_3166_alpha2,
     'ISO-3166-Alpha3': vocab_funcs.construct_iso_3166_alpha3,
     'ISO-3166-Numeric': vocab_funcs.construct_iso_3166_numeric,
     'UN-M49': vocab_funcs.construct_un_m49,
+    'InverseLocation': vocab_funcs.construct_inverse_location,
     'Created': vocab_funcs.construct_date_created,
     'Modified': vocab_funcs.construct_date_modified,
     'Status': vocab_funcs.construct_status,
@@ -109,12 +110,13 @@ SCHEMA['locations'] = {
 SCHEMA['memberships'] = {
     'Term': vocab_funcs.construct_class,
     'Label': vocab_funcs.construct_label,
-    'Definition': vocab_funcs.contruct_definition,
+    'Definition': vocab_funcs.construct_definition,
     'ParentTerm': None,
     'ParentType': vocab_funcs.construct_parent_taxonomy,
     'Members': vocab_funcs.construct_skos_narrower,
     'Start': vocab_funcs.construct_temporal_duration,
     'End': None,
+    'InverseLocation': vocab_funcs.construct_inverse_location,
     'Usage': vocab_funcs.construct_scope_note,
     'Created': vocab_funcs.construct_date_created,
     'Modified': vocab_funcs.construct_date_modified,
@@ -140,7 +142,7 @@ SCHEMA['laws'] = {
 }
 
 SCHEMA['gdpr-rights-justifications'] = SCHEMA['taxonomy'].copy()
-SCHEMA['gdpr-rights-justifications']['Right'] = vocab_funcs.contruct_gdpr_right_justification
+SCHEMA['gdpr-rights-justifications']['Right'] = vocab_funcs.construct_gdpr_right_justification
 
 SCHEMA['examples'] = {
     'Term': vocab_funcs.construct_example,


### PR DESCRIPTION
`InverseLocation` is added to the Locations and Location Memberships CSVs but not yet to their schemas.

Without the `InverseLocation` in the schema, `200_serialise_RDF.py` will failed.

# Pull Request

- Add `InverseLocation` key to `SCHEMA['locations']` and `SCHEMA['memberships']`
- Also fix small typos

## Error message

> INFO - _parse_write :: 556 - VOCAB: loc (https://w3id.org/dpv/loc#)
INFO - _parse_write :: 557 - ----------------------------------------
INFO - _parse_write :: 573 - MODULE: locations - parsing ./vocab_csv/location.csv with schema: locations
Traceback (most recent call last):
  File "/dpv/code/./200_serialise_RDF.py", line 714, in <module>
    _generate_triples(CSVFILES.keys())
  File "/dpv/code/./200_serialise_RDF.py", line 667, in _generate_triples
    global_triples += _parse_write(vocab, vocab_data, write=True)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dpv/code/./200_serialise_RDF.py", line 600, in _parse_write
    func = schema[header[index]]
           ~~~~~~^^^^^^^^^^^^^^^
KeyError: 'InverseLocation'

