### PR TITLE
Add skip and vocabs fields to DATA class in 300_generate_HTML.py

### DIFF
--- a/code/300_generate_HTML.py
+++ b/code/300_generate_HTML.py
@@ -71,7 +71,12 @@ class DATA(object):
     # helpful to create the index search interface.
     outputs = []
     graph = Graph()
-    
+
+    # `vocabs` is a list of vocabularies that are loaded.
+    vocabs = []
+    # `skip` is a list of vocabularies to skip loading.
+    skip = []
+
     # === load-vocab ===
     @staticmethod
     def load_vocab(filepath:str, vocab:str) -> None:
@@ -1088,7 +1093,7 @@ if __name__ == '__main__':
         # any vocab may have examples, so always include dex
         INFO(f'Generating outputs only for {DATA.vocabs}')
     else:
-        INFO(f'Generating outputs for ALL vocabulries')
+        INFO('Generating outputs for ALL vocabularies')
 
     if args.skip:
         DATA.skip = [s.strip() for s in args.skip[0].split(',')]


### PR DESCRIPTION
# Pull Request

If `300_generate_HTML.py` is called without `--skip` argument, the script will failed as `DATA.skip` is accessed but `skip` is not existed in `DATA`.

https://github.com/w3c/dpv/blob/87ed62e1a80c9e995334fdbcdd6aa9fd787983a5/code/300_generate_HTML.py#L877-L878

## Error message

> % ./300_generate_HTML.py
INFO - <module> :: 1085 - ----------------------------------------
INFO - <module> :: 1091 - Generating outputs for ALL vocabulries
INFO - <module> :: 1097 - ----------------------------------------
Traceback (most recent call last):
  File "/dpv/code/./300_generate_HTML.py", line 1098, in <module>
    _load_rdf_data()
  File "/code/./300_generate_HTML.py", line 878, in _load_rdf_data
    DEBUG(DATA.skip)
          ^^^^^^^^^
AttributeError: type object 'DATA' has no attribute 'skip'

This PR adds `skip` (will initialized by `--skip`) and `vocabs` (`--vocab`) fields (as an empty list) to `DATA` class, so they can be accessible even without the argument and avoiding error.
