### PR TITLE
Make 380_open_all_html.sh compatible with macOS "open"

### DIFF
--- a/code/380_open_all_html.sh
+++ b/code/380_open_all_html.sh
@@ -18,7 +18,7 @@ fi
 # MODE="https://w3id.org/dpv"
 # MODE="http://localhost:8000"
 MODE="https://dev.dpvcg.org/2.0"
-MODE="localhost:8000/2.0"
+MODE="http://localhost:8000/2.2-dev"
 
 FILES=(
     # core specs
@@ -89,5 +89,5 @@ done
 
 for i in "${!FILES[@]}"
 do
-    xdg-open ${FILES[i]}
+    $COMMAND ${FILES[i]}
 done


### PR DESCRIPTION
# Pull Request

This PR does two things:

1) Let the script using a proper open command for the OS it is running on.
    - Replacing the hardcoded `xdg-open` (for Linux) in line 92 with `$COMMAND`
    - Another instance of open at line 83 is already properly set

2) Make the localhost URL a fully qualified URL, because it is what macOS "open" expected.
    - For example, `localhost:8000/2.0/risk/index.html` will failed. It has to be `http://localhost:8000/2.0/risk/index.html`.
