### PR TITLE
Fix typos and brackets in Examples

### DIFF
--- a/examples/E0001.ttl
+++ b/examples/E0001.ttl
@@ -1,6 +1,6 @@
 # Example: A Company is running 'Direct Marketing' campaigns for
 # a purpose (CampaignA), within which it runs another special
-# campaign (CampaignB). This may envolve into another campaign C.
+# campaign (CampaignB). This may evolve into another campaign C.
 # RDFS+SKOS modelling
 dpv:Marketing a rdfs:Class, dpv:Purpose .
 dpv:DirectMarketing a dpv:Purpose; skos:broader dpv:Marketing .

--- a/examples/E0004.ttl
+++ b/examples/E0004.ttl
@@ -21,4 +21,4 @@ exA:TVServiceOptimisation skos:broader exB:TVServiceOptimisation .
 exA:TVServiceOptimisation skos:exactMatch exB:TVServiceOptimisation .
 
 # 3: BobCo's optimisations are found to be similar to AliceCo's
-exA:TVServiceOptimisation skos:closeMatch exB:TVServiceOptimisation .<F25>
+exA:TVServiceOptimisation skos:closeMatch exB:TVServiceOptimisation .

--- a/examples/E0005.ttl
+++ b/examples/E0005.ttl
@@ -3,4 +3,4 @@ ex:AcmeMarketing rdf:type dpv:Process ;
     dpv:hasDataController ex:Acme ;
     dpv:hasPersonalData pd:EmailAddress ;
     dpv:hasProcessing dpv:Collect, dpv:Use ;
-    dpv:hasPurpose dpv:ServiceProvision ;
+    dpv:hasPurpose dpv:ServiceProvision .

--- a/examples/E0021.ttl
+++ b/examples/E0021.ttl
@@ -1,5 +1,5 @@
 # 1: directly associating staff training with credentials used
-ex:StaffCredentialsTraining rdf:type dpv:OrganistionalMeasure ;
+ex:StaffCredentialsTraining rdf:type dpv:OrganisationalMeasure ;
     skos:broader dpv:StaffTraining .
 ex:RBACCredential dpv:hasOrganisationalMeasure ex:StaffCredentialTraining .
 
@@ -10,6 +10,6 @@ ex:SecurityPolicy rdf:type dpv:OrganisationalMeasure ;
     dpv:hasTechnicalMeasure dpv:AccessControlMethod .
 
 # 3: indicating staff training contains access control methods
-ex:StaffCredentialsTraining rdf:type dpv:OrganistionalMeasure ;
+ex:StaffCredentialsTraining rdf:type dpv:OrganisationalMeasure ;
     skos:broader dpv:StaffTraining ;
     dpv:hasTechnicalMeasure ex:RBACCredential .

--- a/examples/E0022.ttl
+++ b/examples/E0022.ttl
@@ -1,7 +1,7 @@
 # Associating a Notice with DPV metadata
 ex:Service rdf:type dpv:Process ;
     dpv:hasNotice ex:AcmePrivacyPolicy .
-ex:AcmePrivayPolicy rdf:type dpv:PrivacyNotice ;
+ex:AcmePrivacyPolicy rdf:type dpv:PrivacyNotice ;
     dct:title "Acme's Privacy Policy"@en ;
     foaf:page "https://example.com/"^^xsd:anyURI .
 

--- a/examples/E0042.ttl
+++ b/examples/E0042.ttl
@@ -12,4 +12,4 @@ ex:PDH a dpv:Process ;
 
 ex:CJA2010 a dpv:Law ;
     dct:title "Money Laundering and Terrorist Financing Act 2010" ;
-    dpv:hasJuridiction loc:IE .
+    dpv:hasJurisdiction loc:IE .

--- a/examples/E0043.ttl
+++ b/examples/E0043.ttl
@@ -11,7 +11,7 @@ ex:PDH a dpv:Process ;
     dpv:hasPurpose [
         a dpv:Purpose ;
         skos:broader dpv:AcademicResearch ;
-        dpv:hasSector "Education in University"@en ; # OR link to existin codes
+        dpv:hasSector "Education in University"@en ; # OR link to existing codes
         # NACE Rev 2.1 concept 85 Education
         dpv:hasSector [
             skos:prefLabel "Education in University"@en ;

--- a/examples/E0048.ttl
+++ b/examples/E0048.ttl
@@ -16,7 +16,7 @@ ex:PDH a dpv:Process ;
         dpv:hasDuration [
             a dpv:UntilEventDuration ;
             dpv:hasDuration "P6M" ;
-            dct:description "6 months from acount closure"@en ;
+            dct:description "6 months from account closure"@en ;
         ] ;
     ] ;
     dpv:hasStorageCondition [

--- a/examples/E0049.ttl
+++ b/examples/E0049.ttl
@@ -18,5 +18,5 @@ ex:PDH a dpv:Process ;
         a dpv:SmallScaleOfDataSubjects ; 
         rdf:value "5000"^^xsd:int ; # number of people
     ] ;
-    # Processing Scale - aggretating above as a qualified label
+    # Processing Scale - aggregating above as a qualified label
     dpv:hasProcessingScale dpv:SmallScaleProcessing .

--- a/examples/E0050.ttl
+++ b/examples/E0050.ttl
@@ -9,13 +9,13 @@ ex:PDH1 a dpv:Process ;
     ] ;
     dpv:hasDuration "2023-12-31" ;
     dpv:hasDuration [
-        a dpv:UntilTimeDurationdt ;
+        a dpv:UntilTimeDuration ;
         rdf:value "2023-12-31"^^xsd:date ; # same as above, 
             #  but more explicit that this is an end date
     ] ;
     dpv:hasDuration "1 time"@en ; # bad practice - not machine-readable
     dpv:hasDuration [
-        a dpv:FixedOccurencesDuration ; # good practice - unambigious
+        a dpv:FixedOccurrencesDuration ; # good practice - unambiguous
         rdf:value "1"^^xsd:int ; 
     ] ;
     dpv:hasDuration "until account closure"@en ; # bad practice

--- a/examples/E0051.ttl
+++ b/examples/E0051.ttl
@@ -11,19 +11,19 @@ ex:PDH1 a dpv:Process ;
             # combined with duration - once sometime in 6 months
     ] ;
     dpv:hasFrequency [
-        a dpv:ContinousFrequency ; # data will be continously collected
-            # combined with duration - continous collection for 6 months
+        a dpv:ContinuousFrequency ; # data will be continuously collected
+            # combined with duration - continuous collection for 6 months
     ] ;
     dpv:hasFrequency [
         a dpv:SporadicFrequency ; # data will be sporadically collected
             # combined with duration - collected sporadically across 6 months
         # optionally, the 'frequency' of sporadic collection can also be
-        # expressed as a duration i.e. a preiod
+        # expressed as a duration i.e. a period
         rdf:value "10"^^xsd:duration ; # 10 times (across 6 months)
     ] ;
     dpv:hasFrequency [
         a dpv:OftenFrequency ; # often is qualitatively more than sporadic
-        rdf:value "1" ; # frequency can also be expressed as occurences
+        rdf:value "1" ; # frequency can also be expressed as occurrences
         dpv:hasDuration [ # combined with a duration
             a dpv:TemporalDuration ; 
             rdf:value "P1D"^^xsd:duration ;

--- a/examples/E0051.ttl
+++ b/examples/E0051.ttl
@@ -18,7 +18,7 @@ ex:PDH1 a dpv:Process ;
         a dpv:SporadicFrequency ; # data will be sporadically collected
             # combined with duration - collected sporadically across 6 months
         # optionally, the 'frequency' of sporadic collection can also be
-        # expressed as a duration i.e. a period
+        # expressed as a duration, i.e., a period
         rdf:value "10"^^xsd:duration ; # 10 times (across 6 months)
     ] ;
     dpv:hasFrequency [

--- a/examples/E0052.ttl
+++ b/examples/E0052.ttl
@@ -12,6 +12,4 @@ ex:PDH a dpv:Process ;
         dpv:hasPersonalData pd:Name ;
         dpv:hasNecessity dpv:Optional ;
         dpv:hasImportance dpv:SecondaryImportance ;
-    ] ;
-]. 
-
+    ] .

--- a/examples/E0053.ttl
+++ b/examples/E0053.ttl
@@ -3,7 +3,7 @@ ex:PDH a dpv:Process ;
     dpv:hasPersonalData dpv:NotAvailable ; 
     # personal data is not involved, so we specify not applicable
     dpv:hasPersonalData dpv:NotApplicable ;
-    # we don't know yet if personal data is invovled - so it is unknown
+    # we don't know yet if personal data is involved - so it is unknown
     dpv:hasPersonalData dpv:UnknownApplicability ;
     # another way to indicate applicability - we know some personal data
     # is involved but we don't know anything more about it

--- a/examples/E0056.ttl
+++ b/examples/E0056.ttl
@@ -5,7 +5,7 @@ ex:PDH-DPIA-202402 a dpv:DPIA ;
     dct:subject ex:CorpService ; # DPIA covering Corp. Service
     dct:date "2024-01-01"^^xsd:date ;
     dct:conformsTo ex:OrgPolicy ;
-    dpv:hasAuditStatus dpv:AuditRequired ; # an audit is requred 
+    dpv:hasAuditStatus dpv:AuditRequired ; # an audit is required 
     dpv:hasAuditStatus dpv:AuditApproved ; # status if no details are needed
     # or to specify more details about the audit
     dpv:hasAuditStatus [

--- a/examples/E0065.ttl
+++ b/examples/E0065.ttl
@@ -6,7 +6,7 @@ ex:PDH a dpv:Process ;
     dpv:hasPurpose dpv:FraudPreventionDetection ;
     # bad practice - always specify whose legitimate interest
     dpv:hasLegalBasis dpv:LegitimateInterest ;
-    # better - is clear and unambigious 
+    # better - is clear and unambiguous 
     dpv:hasDataController ex:AcmeInc ;
     dpv:hasLegalBasis dpv:LegitimateInterestOfController ;
     # again bad practice if there are multiple controllers involved
@@ -25,7 +25,7 @@ ex:PDH a dpv:Process ;
 
 # if legitimate interest is to be defined outside of a process,
 # additional relevant information can be added to it
-# though we *strongly* recommend always using a process and delcaring
+# though we *strongly* recommend always using a process and declaring
 # purpose, legal basis, etc. separately and explicitly
 # The below shows three different ways to indicate the same information
 # - so the adopter can choose the best 'fit' for their internal representation

--- a/examples/E0068.ttl
+++ b/examples/E0068.ttl
@@ -21,7 +21,7 @@ ex:R1DB a dpv:Risk ;
     ] ;
     dpv:hasImpact [
       a dpv:Risk, risk:MisuseBreachedInformation, risk:IdentityFraud ;
-      skos:prefLabel "Breached information may be misued in identity fraud"@en ;
+      skos:prefLabel "Breached information may be misused in identity fraud"@en ;
       dpv:hasImpactOn dpv:DataSubject ;
       dpv:hasLikelihood risk:LowLikelihood ;
       dpv:hasSeverity risk:HighSeverity ;

--- a/examples/E0069.ttl
+++ b/examples/E0069.ttl
@@ -7,7 +7,7 @@ ex:IN11 a risk:Incident ;
     dpv:hasImpact [
       a risk:Incident, risk:MisuseBreachedInformation, risk:IdentityFraud ;
       dpv:hasStatus risk:IncidentOngoing ;
-      skos:prefLabel "Breached information may be misued in identity fraud"@en ;
+      skos:prefLabel "Breached information may be misused in identity fraud"@en ;
       dpv:hasImpactOn dpv:DataSubject ;
       dpv:hasSeverity risk:HighSeverity ;
     ] ;

--- a/examples/E0072.ttl
+++ b/examples/E0072.ttl
@@ -21,20 +21,20 @@ ex:ExampleNotice a dpv:ConsentNotice ;
         # link to full privacy notice for the service
         dpv:hasNotice "https://example.com/privacy-notice"^^xsd:anyURI ;
         dpv:hasProcess [ # process for use of location
-                a dpv:Process ;
-                dpv:hasPurpose dpv:ServicePersonalisation ;
-                dpv:hasPersonalData pd:Location ;
-                dpv:hasProcessing dpv:Collect, dpv:Use ;
-                dpv:hasLegalBasis eu-gdpr:A6-1-a ;
-            ], [ # process stating location is also used to prevent fraud
-                a dpv:Process ;
-                dpv:hasPurpose dpv:FraudPreventionAndDetection ;
-                dpv:hasPersonalData pd:Location ;
-                dpv:hasProcessing dpv:Collect, dpv:Store, dpv:Use ;
-                dpv:hasLegalBasis dpv:LegitimateInterest ;
-                dpv:hasStorageLocation loc:EU ;
-                dpv:hasRecipient ex:AcmeInc ;
-            ] ;
+            a dpv:Process ;
+            dpv:hasPurpose dpv:ServicePersonalisation ;
+            dpv:hasPersonalData pd:Location ;
+            dpv:hasProcessing dpv:Collect, dpv:Use ;
+            dpv:hasLegalBasis eu-gdpr:A6-1-a ;
+        ], [ # process stating location is also used to prevent fraud
+            a dpv:Process ;
+            dpv:hasPurpose dpv:FraudPreventionAndDetection ;
+            dpv:hasPersonalData pd:Location ;
+            dpv:hasProcessing dpv:Collect, dpv:Store, dpv:Use ;
+            dpv:hasLegalBasis dpv:LegitimateInterest ;
+            dpv:hasStorageLocation loc:EU ;
+            dpv:hasRecipient ex:AcmeInc ;
+        ] ;
         dpv:hasConsentControl [
             a dpv:ManageConsent ; 
             dct:title "Manage Consent"@en ;
@@ -54,5 +54,4 @@ ex:ExampleNotice a dpv:ConsentNotice ;
         dpv:hasDataController ex:Company ;
         dpv:hasDataProcessor ex:AcmeInc ;
         dpv:hasApplicableLaw legal-eu:law-GDPR ;
-        ] ;
     ] .

--- a/examples/E0073.ttl
+++ b/examples/E0073.ttl
@@ -52,7 +52,7 @@ ex:NoticeLog1 a dpv:DataProcessingRecord, dpv:NoticeStatus ;
         dct:date "2025-01-04"^^xsd:date ;
     ] .
 
-# Method 4: Track notice lifcycle in the notice itself
+# Method 4: Track notice lifecycle in the notice itself
 ex:ExampleNotice a dpv:Notice ;
     dpv:hasNoticeStatus [
         a dpv:NoticeStatus ;

--- a/examples/E0085.ttl
+++ b/examples/E0085.ttl
@@ -29,6 +29,3 @@ ex:SomeProcess a dpv:Process ;
 ex:AnotherProcess a dpv:Process ;
     dpv:hasProcess ex:SomeProcess ; # collect, store location by Acme
     dpv:hasProcess ex:SomeOtherProcess . # share location with Beta
-
-
-

--- a/examples/E0086.ttl
+++ b/examples/E0086.ttl
@@ -14,8 +14,8 @@ ex:SomeProcess a dpv:Process ;
   ] ;
   risk:hasControl [
     a risk:RiskControl ;
-    a risk:DetectionControl, risk:ContaimmentControl, risk:LoggingControl ;
-    risk:detects ex:UnwantedEvent ; # detect risk occuring
+    a risk:DetectionControl, risk:ContainmentControl, risk:LoggingControl ;
+    risk:detects ex:UnwantedEvent ; # detect risk occurring
     risk:contains ex:UnwantedEvent ; # if it occurs, contain it
     risk:logs ex:UnwantedEvent ; # record it occurred
   ] ;


### PR DESCRIPTION
# Pull Request

- Fix minor typos in Examples
- These include typos in concepts listed in 2.0 Change Log like `ContinousFrequency` and `FixedOccurencesDuration`: https://github.com/w3c/dpv/blob/master/2.0/changelog.html
- Remove `<F25>` (probably a conversion of a control character by a text editor) from E0004
- Remove extra closing brackets

(Concepts in 1.0-specific Examples are kept intact) 