### PR TITLE
Fix Markdown of Sector list in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ These extensions provide additional concepts that extend the concepts and scope 
 - [Risk](https://w3id.org/dpv/risk) provides concepts for risk assessment and management;
 
 In v2.1, the Sector and Standard group of extensions was added to the DPV specifications. [Sector](https://w3id.org/dpv/sector) provides sector-specific concepts which extend concepts in other DPV extensions. Currently, the following sectors are represented:
--[SECTOR-EDUCATION](https://w3id.org/dpv/sector/education) for Education Sector
--[SECTOR-FINANCE](https://w3id.org/dpv/sector/finance) for Finance Sector
--[SECTOR-HEALTH](https://w3id.org/dpv/sector/health) for Health Sector
--[SECTOR-INFRA](https://w3id.org/dpv/sector/infra) for (Critical) Infrastructure Sector
--[SECTOR-LAW](https://w3id.org/dpv/sector/law) for Law Enforcement & Justice Sector
--[SECTOR-PUBLICSERVICES](https://w3id.org/dpv/sector/publicservices) for Public Services Sector
+
+- [SECTOR-EDUCATION](https://w3id.org/dpv/sector/education) for Education Sector
+- [SECTOR-FINANCE](https://w3id.org/dpv/sector/finance) for Finance Sector
+- [SECTOR-HEALTH](https://w3id.org/dpv/sector/health) for Health Sector
+- [SECTOR-INFRA](https://w3id.org/dpv/sector/infra) for (Critical) Infrastructure Sector
+- [SECTOR-LAW](https://w3id.org/dpv/sector/law) for Law Enforcement & Justice Sector
+- [SECTOR-PUBLICSERVICES](https://w3id.org/dpv/sector/publicservices) for Public Services Sector
 
 The Standards extensions are aimed to provide additional concepts for implementing specific standards using DPV. Currently it contains [IEEE-P7012](https://w3id.org/dpv/standards/p7012) based on [IEEE P7012 Draft Standard for Machine Readable Personal Privacy Terms](https://standards.ieee.org/ieee/7012/7192/).
 


### PR DESCRIPTION
# Pull Request

- Add a missing space after `-` at the beginning of each bullet
- Add a missing blank line before the bullet list

(This can also apply to README in `master` and in `2.3-dev`)

### Screenshots

Current:
<img width="876" height="231" alt="Screenshot 2025-07-22 at 08 40 10" src="https://github.com/user-attachments/assets/b686833f-ec1b-4218-b1c1-04815f3f5465" />

After Markdown fix:
<img width="875" height="366" alt="Screenshot 2025-07-22 at 08 44 59" src="https://github.com/user-attachments/assets/751291d8-38c8-4794-aa7a-cbfe06a765d5" />
