### PR TITLE
Use {{DPV_VERSION}} variable in Changelog title in templates

### DIFF
--- a/code/jinja2_resources/template_ai.jinja2
+++ b/code/jinja2_resources/template_ai.jinja2
@@ -92,7 +92,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -339,8 +339,8 @@
 {% endblock ACKNOWLEDGEMENTS %}
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_dpv.jinja2
+++ b/code/jinja2_resources/template_dpv.jinja2
@@ -939,8 +939,8 @@
 </section>
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <section class="appendix" id="issue-summary"></section>

--- a/code/jinja2_resources/template_justifications.jinja2
+++ b/code/jinja2_resources/template_justifications.jinja2
@@ -60,7 +60,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -194,8 +194,8 @@
 {% endblock ACKNOWLEDGEMENTS %}
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_legal_eu_aiact.jinja2
+++ b/code/jinja2_resources/template_legal_eu_aiact.jinja2
@@ -60,7 +60,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -359,8 +359,8 @@ ex:PDH3 a dpv:Process ;
 <section class="appendix" id="issue-summary"></section>
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../../../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_legal_eu_dga.jinja2
+++ b/code/jinja2_resources/template_legal_eu_dga.jinja2
@@ -60,7 +60,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -236,8 +236,8 @@ ex:PDH2 a dpv:Process ;
 <section class="appendix" id="issue-summary"></section>
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../../../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_legal_eu_gdpr.jinja2
+++ b/code/jinja2_resources/template_legal_eu_gdpr.jinja2
@@ -56,7 +56,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -588,8 +588,8 @@ ex:PDH2 a dpv:Process ;
 <section class="appendix" id="issue-summary"></section>
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../../../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_legal_eu_nis2.jinja2
+++ b/code/jinja2_resources/template_legal_eu_nis2.jinja2
@@ -56,7 +56,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -187,8 +187,8 @@ ex:PDH2 a dpv:Process ;
 {% endblock PROPOSED %}
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../../../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_legal_eu_rights.jinja2
+++ b/code/jinja2_resources/template_legal_eu_rights.jinja2
@@ -55,7 +55,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -171,8 +171,8 @@
 <section class="appendix" id="issue-summary"></section>
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../../../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_locations.jinja2
+++ b/code/jinja2_resources/template_locations.jinja2
@@ -56,7 +56,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -578,8 +578,8 @@ loc:non-IE a dpv:InverseJurisdiction ;
 <section class="appendix" id="issue-summary"></section>
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_p7012.jinja2
+++ b/code/jinja2_resources/template_p7012.jinja2
@@ -509,7 +509,7 @@
 {# <section class="appendix" id="issue-summary"></section> #}
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
   <p><strong>total terms: 165 ; added: 165 ; removed: 0 ;</strong></p>
   <p>The <a href="../changelog.html">changelog</a> provides more information on concepts that have been added/removed in this version.</p>
 </section>

--- a/code/jinja2_resources/template_pd.jinja2
+++ b/code/jinja2_resources/template_pd.jinja2
@@ -54,7 +54,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -213,8 +213,8 @@
 {# <section class="appendix" id="issue-summary"></section> #}
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_risk.jinja2
+++ b/code/jinja2_resources/template_risk.jinja2
@@ -93,7 +93,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -642,8 +642,8 @@
 <section class="appendix" id="issue-summary"></section>
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../diagrams/common.js" defer></script>

--- a/code/jinja2_resources/template_tech.jinja2
+++ b/code/jinja2_resources/template_tech.jinja2
@@ -55,7 +55,7 @@
         "key": "Changelog",
         "data": [
             {
-              "value": "Changelog for v2.1",
+              "value": "Changelog for v{{DPV_VERSION}}",
               "href": "#changelog"
             }
         ]
@@ -348,8 +348,8 @@ ex:DatabaseDocs a tech:Instructions ;
 <section class="appendix" id="issue-summary"></section>
 
 <section id="changelog">
-  <h2>Changelog for v2.1</h2>
-  <div class="issue" title="Changelog for v2.1"></div>
+  <h2>Changelog for v{{DPV_VERSION}}</h2>
+  <div class="issue" title="Changelog for v{{DPV_VERSION}}"></div>
 </section>
 
 <script type="text/javascript" src="../diagrams/common.js" defer></script>


### PR DESCRIPTION
Instead of hardcoded version (currently "v2.1")

# Pull Request

To fix version number in changelog section.

Currently it shows like this for 2.2:

<img width="335" height="151" alt="Screenshot 2568-07-23 at 16 22 15" src="https://github.com/user-attachments/assets/418bb3ba-a93e-4255-abfa-6b01c512ee8f" />

300_generate_HTML.py is running ok with the changes and generating "Changelog for v2.2" text.


(This PR targets the `dev` branch. Needs to apply the same for the `2.3-dev` branch too.) 