### PR TITLE
Use DPV_VERSION for path in link/img

### DIFF
--- a/code/jinja2_resources/template_guides_consent_27560.jinja2
+++ b/code/jinja2_resources/template_guides_consent_27560.jinja2
@@ -221,7 +221,7 @@
         <li><strong>Events:</strong> information about <i>consent events</i> e.g. consent given, consent withdrawn.</li>
     </ol>
     <figure>
-        <img src="../2.0/diagrams/dpv-27560-summary.png">
+        <img src="../{{DPV_VERSION}}/diagrams/dpv-27560-summary.png">
         <figcaption>Summary of fields in ISO/IEC TS 27560:2023. The field names have been modified for alignment with DPV concepts. Field names in bold are mandatory.</figcaption>
     </figure>
     <p>Each section contains fields which describe the information that must be represented along with the form (e.g. timestamp format) and its necessity (e.g. required or optional). Certain fields are expressed as references to other fields (e.g. 'Controller' in 'Processing' section is a reference to an instance or record in 'Parties' section).</p>

--- a/code/jinja2_resources/template_mappings_dcat.jinja2
+++ b/code/jinja2_resources/template_mappings_dcat.jinja2
@@ -74,6 +74,6 @@
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-<script type="text/javascript" src="../../2.0/diagrams/common.js" defer></script>
+<script type="text/javascript" src="../../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>

--- a/code/jinja2_resources/template_mappings_dct.jinja2
+++ b/code/jinja2_resources/template_mappings_dct.jinja2
@@ -74,6 +74,6 @@
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-<script type="text/javascript" src="../../2.0/diagrams/common.js" defer></script>
+<script type="text/javascript" src="../../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>

--- a/code/jinja2_resources/template_mappings_gist.jinja2
+++ b/code/jinja2_resources/template_mappings_gist.jinja2
@@ -74,6 +74,6 @@
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-<script type="text/javascript" src="../../2.0/diagrams/common.js" defer></script>
+<script type="text/javascript" src="../../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>

--- a/code/jinja2_resources/template_mappings_index.jinja2
+++ b/code/jinja2_resources/template_mappings_index.jinja2
@@ -79,6 +79,6 @@
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-<script type="text/javascript" src="../../2.0/diagrams/common.js" defer></script>
+<script type="text/javascript" src="../../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>

--- a/code/jinja2_resources/template_mappings_odrl.jinja2
+++ b/code/jinja2_resources/template_mappings_odrl.jinja2
@@ -424,6 +424,6 @@
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-<script type="text/javascript" src="../../2.0/diagrams/common.js" defer></script>
+<script type="text/javascript" src="../../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>

--- a/code/jinja2_resources/template_mappings_prov.jinja2
+++ b/code/jinja2_resources/template_mappings_prov.jinja2
@@ -74,6 +74,6 @@
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-<script type="text/javascript" src="../../2.0/diagrams/common.js" defer></script>
+<script type="text/javascript" src="../../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>

--- a/code/jinja2_resources/template_mappings_schema.jinja2
+++ b/code/jinja2_resources/template_mappings_schema.jinja2
@@ -74,6 +74,6 @@
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-<script type="text/javascript" src="../../2.0/diagrams/common.js" defer></script>
+<script type="text/javascript" src="../../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>

--- a/code/jinja2_resources/template_mappings_semic.jinja2
+++ b/code/jinja2_resources/template_mappings_semic.jinja2
@@ -74,6 +74,6 @@
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-<script type="text/javascript" src="../../2.0/diagrams/common.js" defer></script>
+<script type="text/javascript" src="../../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>

--- a/code/jinja2_resources/template_primer.jinja2
+++ b/code/jinja2_resources/template_primer.jinja2
@@ -68,7 +68,7 @@
     localBiblio: {%  include 'references.json' %}
   };
   </script>
-  <link rel="stylesheet" type="text/css" href="../2.0/diagrams/common.css">
+  <link rel="stylesheet" type="text/css" href="../{{DPV_VERSION}}/diagrams/common.css">
 </head>
 
 <body>
@@ -124,18 +124,18 @@
   <section id="core-concepts-overview">
     <h3>Overview of Core Concepts</h3>
     <figure>
-      <img src="../2.0/diagrams/dpv_core.svg">
+      <img src="../{{DPV_VERSION}}/diagrams/dpv_core.svg">
       <figcaption>Overview of concepts in DPV 2.0 - red indicates new concepts and blue indicates expansion of scope to include (non-personal) data and technologies</figcaption>
     </figure>
 
     <section class="notoc"><h4>Purpose</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_Purpose.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_Purpose.svg"/>
         <figcaption>Specifying Purpose using DPV</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-purposes">DPV spec</a> 
+        <a href="../{{DPV_VERSION}}/dpv#vocab-purposes">DPV spec</a> 
       </p>
     </blockquote>
     <p>Representing the <em>purpose</em> for which personal data is processed, for e.g. ‘Personalisation’ as a broad category of purpose. Information about the purpose can be further specified by denoting information about its interpretation within a particular <code>Sector</code>, such as from standardised authoritative lists e.g. [[NACE]], to indicate domain-specific applications and interpretations, or to indicate applicability of sectorial laws.</p>
@@ -143,12 +143,12 @@
 
     <section class="notoc"><h4>Data and Personal Data</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_PD.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_PD.svg"/>
         <figcaption>Specifying use of Data and Personal Data using DPV</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-personal-data">DPV spec</a>
+        <a href="../{{DPV_VERSION}}/dpv#vocab-personal-data">DPV spec</a>
       </p>
     </blockquote>
     <p>‘Personal data’ refers to data about a natural person. ‘Personal data’ is also commonly referred to as ‘personally identifiable information (PII)’. However the terms should not be interchangeably used as based on definitions (e.g. those in GDPR), ‘personal data’ can be interpreted as a broader term than PII, and where PII may refer <u>only</u> to information that can directly identify a person. DPV’s definition of personal data is based on the broadest possible definition (i.e. from GDPR) as it covers a wider range of information considered ‘personal data’. Personal data can be declared as a category, such as ‘<i>Email</i>’, or an instance, such as ‘<i>x@y.z</i>’.</p>
@@ -156,12 +156,12 @@
     
     <section class="notoc"><h4>Processing</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_Processing.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_Processing.svg"/>
         <figcaption>Specifying Processing operations on data using DPV</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-processing">DPV spec</a> 
+        <a href="../{{DPV_VERSION}}/dpv#vocab-processing">DPV spec</a> 
       </p>
     </blockquote>
     <p>Representing <em>processing</em> as in the actions or operations over personal data, for e.g. collect, use, share, store. To indicate the origin or source of data, the concept <code>DataSource</code> along with relation <code>hasDataSource</code> is provided. For additional <i>contextual</i> information regarding operations or processing, such as whether it include humans or automation, the concept <code>ProcessingContext</code> is provided which can be associated using the relation <code>hasContext</code> (description of <code>Context</code> is provided later in the document). Examples of <i>ProcessingContext</i> include conditions such as profiling, automated decision making, human involvement.</p>
@@ -169,12 +169,12 @@
 
     <section class="notoc"><h4>Processing and Storage Conditions</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_Storage.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_Storage.svg"/>
         <figcaption>Specifying temporal and geo-spatial context associated with processing and storage using DPV</figcaption>
       </figure>
       <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-processing-context-processing">DPV spec</a>
+        <a href="../{{DPV_VERSION}}/dpv#vocab-processing-context-processing">DPV spec</a>
       </p>
     </blockquote>
     <p>Indicating information about conditions or limitations associated with processing (including storage) of personal data - such as its location, duration, deletion (e.g. erasure mechanisms), or restoration (e.g. backup availability).</p>
@@ -182,57 +182,57 @@
 
     <section class="notoc"><h4>Legal Basis</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_LegalBasis.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_LegalBasis.svg"/>
         <figcaption>Specifying legal basis using DPV</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-legal-basis">DPV spec</a> 
+        <a href="../{{DPV_VERSION}}/dpv#vocab-legal-basis">DPV spec</a> 
       </p>
     </blockquote>
     <p> A legal basis is a law or a clause in a law that justifies or permits the processing of personal data or use of technologies in the specified manner. It is a jurisdictional concept given the scoping of laws to specified countries or regions, as well as a domain-specific concept given the specific laws enacted scoped to particular domains. A law, such as the GDPR, that regulates the use of personal data requires that every processing of personal data must be justified with some legal basis to ensure it is lawful, and to further assess its correctness, accountability, and impact based on the obligations applicable. However, what is considered a legal basis varies greatly across cultures, domains, use-cases, and laws themselves. The aim of DPV is therefore to provide an upper-level abstract taxonomy of categories of legal bases, such as consent and contract, that can be customised and applied as needed.</p>
     </section>
     <section class="notoc"><h4>Entities</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_Entities.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_Entities.svg"/>
         <figcaption>Specifying entities using DPV</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-entities">DPV spec</a> 
+        <a href="../{{DPV_VERSION}}/dpv#vocab-entities">DPV spec</a> 
       </p>
     </blockquote>
     <p>Representing the ‘entities’ or ‘actors’ involved in the processing of personal data. DPV provides a broad categorisation of entities based on their relevance in jurisprudence (i.e. legal roles) as well as categorisation in real-world (e.g. organisation types).</p>
     </section>
     <section class="notoc"><h4>Data Controller</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_DataController.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_DataController.svg"/>
         <figcaption>Specifying Data Controller entity using DPV</figcaption>
       </figure>
     <p>Representing the organisation(s) responsible for processing the personal data.</p>
     </section>
     <section class="notoc"><h4>DataSubject</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_DataSubject.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_DataSubject.svg"/>
         <figcaption>Specifying Data Subject entity using DPV</figcaption>
       </figure>
     <p>Representing the categories or groups (e.g. Users of a Service), or instances (e.g. Jane Doe) of individual(s) whose personal data is being processed.</p>
     </section>
     <section class="notoc"><h4>Recipient</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_Recipient.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_Recipient.svg"/>
         <figcaption>Specifying Recipient entities using DPV</figcaption>
       </figure>
     <p>Represents the entities that receive personal data, e.g. when it is being collected, or transferred, or shared.</p>
     </section>
     <section class="notoc"><h4>Technical Organisational Measure</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_TechnicalOrganisationalMeasure.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_TechnicalOrganisationalMeasure.svg"/>
         <figcaption>Specifying Technical, Organisational, Legal, and Physical measures using DPV</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-TOM">DPV spec</a> 
+        <a href="../{{DPV_VERSION}}/dpv#vocab-TOM">DPV spec</a> 
       </p>
     </blockquote>
     <p>DPV provides a taxonomy of technical and organisational measures for representing information about how the processing of personal data is technically and organisationally protected, safeguarded, secured, or otherwise managed. This is distinct from what technology is used for carrying out processing, and instead refers to what <i>measures</i> are in place (i.e. what the technology intends to provide in terms of features).</p>
@@ -241,12 +241,12 @@
 
     <section class="notoc"><h4>Location and Jurisdiction</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_Location.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_Location.svg"/>
         <figcaption>Specifying Location and Jurisdiction using DPV</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-context-jurisdiction">DPV spec</a> 
+        <a href="../{{DPV_VERSION}}/dpv#vocab-context-jurisdiction">DPV spec</a> 
       </p>
     </blockquote>
     <p>Representing the locations associated with entities, processing, data, and other information that is important to consider jurisdictions and from that understand the applicability of laws, involvement of authorities, and discover rights.</p>
@@ -254,24 +254,24 @@
 
     <section class="notoc"><h4>Risk</h4>
     <figure>
-        <img src="../2.0/diagrams/risk.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/risk.svg"/>
         <figcaption>Specifying Risk Assessment using DPV</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-risk">DPV spec</a> 
+        <a href="../{{DPV_VERSION}}/dpv#vocab-risk">DPV spec</a> 
       </p>
     </blockquote>
     <p>Risk refers to potential negative events. DPV enables representing risk(s) associated with a concept, for e.g. risk of unauthorised data disclosure related to processing, technical measure, or vulnerability of data subjects. In addition to the risk, DPV also enables representing the consequences (e.g. denial of service) and their impacts for specific entities (e.g. right violated for data subject).</p>
   </section>
   <section class="notoc"><h4>Technology</h4>
     <figure>
-        <img src="../2.0/diagrams/overview_Technology.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/overview_Technology.svg"/>
         <figcaption>Specifying Technology using DPV. The TECH extension provides additional concepts to describe the technology such as involved actors, intended use, capabilities and functions, and documentation</figcaption>
       </figure>
     <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-technology">DPV spec</a>
+        <a href="../{{DPV_VERSION}}/dpv#vocab-technology">DPV spec</a>
       </p>
     </blockquote>
     <p>Representing the technologies used to implement the processing, or associated with the processing. For example, software products, cloud services, or AI technologies. This also involves specifying who is doing the implementing i.e. a technology and its implementer.</p>
@@ -279,12 +279,12 @@
 
     <section class="notoc"><h4>Rights</h4>
     <figure>
-        <img src="../2.0/diagrams/rights.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/rights.svg"/>
         <figcaption>Specifying Rights and Rights Exercise information using DPV</figcaption>
       </figure>
       <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-rights">DPV spec</a>
+        <a href="../{{DPV_VERSION}}/dpv#vocab-rights">DPV spec</a>
       </p>
     </blockquote>
       <p>The concept <code>Right</code> represents a normative concept for what is permissible or necessary in accordance with a system such as laws. To associate rights with concepts that are relevant or within which those rights occur, the relation <code>hasRight</code> is used. Rights can be <i>passive</i>, which means they are always applicable without requiring anything to be done, or <i>active</i> where they require some action to be taken to initiate or exercise them. To represent these concepts, DPV uses <code>PassiveRight</code> and <code>ActiveRight</code> respectively. Rights can be applicable to different contexts or entities. To differentiate rights applicable or afforded to data subjects, the concept <code>DataSubjectRight</code> is used.</p>
@@ -292,12 +292,12 @@
 
     <section class="notoc"><h4>Rules</h4>
     <figure>
-        <img src="../2.0/diagrams/Rules.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/Rules.svg"/>
         <figcaption>Specifying Rights and Rights Exercise information using DPV</figcaption>
       </figure>
       <blockquote>
       <p>see more information: 
-        <a href="../2.0/dpv#vocab-rules">DPV spec</a>
+        <a href="../{{DPV_VERSION}}/dpv#vocab-rules">DPV spec</a>
       </p>
     </blockquote>
       <p>Rules are relevant to explicitly denote how a system should implement operations, and enable associating specifics such as requirements, constraints, and other forms of 'rules' that are needed in order to control executions or affect interpretations or achieve compliance (e.g. with law). DPV defines the concept <code>Rule</code> and relation <code>hasRule</code> to enable representation of such conditions and requirements, and provides a minimal set of concepts for types of rules, namely - representing Permissions, Prohibitions, and Obligations. DPV does not define additional semantics for rules and limits its scope and focus to provide a simple way to specify common rules associated with personal data and its processing activities, with the recommendation to consider other richer and mature efforts dedicated to expression of conditions and rules, such as: [[ODRL]], [[SHACL]], and [[RuleML]].</p>
@@ -307,7 +307,7 @@
   <section id="process">
     <h3>Process</h3>
     <figure>
-      <img src="../2.0/diagrams/process.svg">
+      <img src="../{{DPV_VERSION}}/diagrams/process.svg">
       <figcaption></figcaption>
     </figure>
     <p>In legal terminology, it is common to refer to all information about how personal data is being processed using the colloquial term <i>processing</i>. This results in confusion between the use of <i>processing</i> as a concept referring to all information (i.e. purposes, personal data, collection, storage, etc.), and <code>processing</code> as a concept referring to (only) the specific actions or operations (e.g. collect, use).</p>
@@ -327,7 +327,7 @@
     <p>An example of where the adopter or use-case wants to use another concept in a way which is not compatible with <code>Purpose</code> is the use of <code>Purpose</code> to indicate it involves some data i.e. <code>&lt;SomePurpose hasPersonalData SomePersonalData&gt;</code>, or to indicate which legal basis is used for that purpose by using the <code>hasLegalBasis</code> relationship. While not explicitly prohibited by DPV, the implications of using <code>Purpose</code> in this manner is that the personal data and processing and other associated concepts are now strictly tied to the purpose instance (and implementation). Changing any of these would mean changing the purpose, and in addition to these, it is not possible to combine multiple purposes together or have nested purposes with different details in the same manner as with a <code>Process</code>. Therefore, DPVCG recommends the use of <code>Process</code> to ensure compatibility between use-cases as well as to ensure the use of concepts does not create ambiguity or restrict further use-cases from reusing existing information.</p>
     <!-- <p>The following figure indicates an alternate model which does not use <code>Process</code> as a central concept, but instead uses the core concepts and relationships to structure information related to a <i>Service</i>.</p>
     <figure>
-      <img src="../2.0/diagrams/alt_model_PDH.svg">
+      <img src="../{{DPV_VERSION}}/diagrams/alt_model_PDH.svg">
       <figcaption>Alternate model to <code>Process</code> using core concepts and relationships</figcaption>
     </figure>
     <aside class="example" title="Alternative to Process: using Purpose to combine core concepts">
@@ -396,7 +396,7 @@ ex:AcmeMarketing rdf:type dpv:Purpose ;
       <h3>Concepts and Relationships</h3>
       <p>[[DPV]] is a collection of <i>concepts</i>. Here the term 'concept' is broadly used as consisting of a <i>term</i> non-exhaustively representing any of the following: idea, thought, meaning, object, event, relations, class, or category. Thus, in DPV, 'concepts' consist of terms and relationships between them.</p>
       <figure>
-        <img src="../2.0/diagrams/concepts_relations.svg"/>
+        <img src="../{{DPV_VERSION}}/diagrams/concepts_relations.svg"/>
         <figcaption>Semantic relationships between concepts used in DPV - generalisation and specialisation (arrowhead), instantiation, and association</figcaption>
       </figure>
       <aside class="example">
@@ -697,6 +697,6 @@ ex:AcmeMarketing rdf:type dpv:Purpose ;
 
 </section>
 {% endblock ACKNOWLEDGEMENTS %}
-  <script type="text/javascript" src="../2.0/diagrams/common.js" defer></script>
+  <script type="text/javascript" src="../{{DPV_VERSION}}/diagrams/common.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
# Pull Request

In Primer, links to vocabularies are still point to 2.0, update that in Jinja template.

Also update URL for image and JavaScript sources for other templates.