### PR TITLE
Replace character U+2013 "–" with ASCII U+002d "-" in PlantUML source…

### DIFF
--- a/2.2/diagrams/plantuml/Consequences.plantuml
+++ b/2.2/diagrams/plantuml/Consequences.plantuml
@@ -18,10 +18,10 @@ package dpv {
 	class NonMaterialDamage
 }
 Thing -- Consequence : hasConsequence >
-Consequence <|-– Impact
-Consequence <|-– ConsequenceAsSideEffect
-Consequence <|-– ConsequenceOfFailure
-Consequence <|-– ConsequenceOfSuccess
+Consequence <|-- Impact
+Consequence <|-- ConsequenceAsSideEffect
+Consequence <|-- ConsequenceOfFailure
+Consequence <|-- ConsequenceOfSuccess
 Impact <|-- Benefit
 Impact <|-- Damage
 Impact <|-- Detriment

--- a/2.2/diagrams/plantuml/gdpr_Overview.plantuml
+++ b/2.2/diagrams/plantuml/gdpr_Overview.plantuml
@@ -38,7 +38,7 @@ Process -d- dpv.DataProtectionAuthority: hasAuthority >
 'Right <|-d- DataSubjectRight
 'OrganisationalMeasure <|-d- GuidelinesPrinciple
 'GuidelinesPrinciple <|-d- Principle
-'Entity <|–d- LegalEntity
+'Entity <|-d- LegalEntity
 'LegalEntity <|-d- Organisation
 
 /'

--- a/2.2/diagrams/plantuml/overview_Data.plantuml
+++ b/2.2/diagrams/plantuml/overview_Data.plantuml
@@ -56,8 +56,8 @@ Data <|-- PersonalData
 Data <|-- SensitiveData
 Data <|-- UnverifiedData
 Data <|-- VerifiedData
-DerivedData <|–- DerivedPersonalData
-DerivedData <|–- InferredData
+DerivedData <|-- DerivedPersonalData
+DerivedData <|-- InferredData
 DerivedPersonalData <|-- InferredPersonalData
 GeneratedData <|-- SyntheticData
 InferredData <|-- InferredPersonalData
@@ -65,10 +65,10 @@ NonPersonalData <|-- AnonymisedData
 ObservedData <|-- ObservedPersonalData
 PersonalData <|-- CollectedPersonalData
 PersonalData <|-- SensitivePersonalData
-PersonalData <|–- DerivedPersonalData
-PersonalData <|–- GeneratedPersonalData
-PersonalData <|–- IdentifyingPersonalData
-PersonalData <|–- PseudonymisedData
+PersonalData <|-- DerivedPersonalData
+PersonalData <|-- GeneratedPersonalData
+PersonalData <|-- IdentifyingPersonalData
+PersonalData <|-- PseudonymisedData
 ProvidedData <|-- ProvidedPersonalData
 PseudonymisedData <|-- ContextuallyAnonymisedData
 SensitiveData <|-- SensitiveNonPersonalData
@@ -76,7 +76,5 @@ SensitiveData <|-- SensitivePersonalData
 SensitivePersonalData <|-- SpecialCategoryPersonalData
 Thing -- Data : hasData >
 Thing -- PersonalData : hasPersonalData >
-
-
 
 @enduml


### PR DESCRIPTION
# Pull Request

(Not related to the content of DPV)

- In PlantUML source codes (*.plantuml), replace character U+2013 "–" (en dash) with the ASCII character U+002d "-" (hyphen-minus) which is more common for source code
- This bring no change to the diagram as recent versions of PlantUML parser can handle U+2013 without problem
  - It is just a best practice to use ASCII characters in non-string/non-comment parts of source code to avoid possible issues and to make it similar to other parts of the code (will be convenient for search as well)
- Tested with PlantUML v1.2025.4, works all fine