### PR TITLE
Add search and changelog links to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -27,7 +27,7 @@
     <div id="wb404"/>
     <script src="https://archive.org/web/wb404.js"></script>
 
-    <p><strong>DPV v2.2</strong><br/>
+    <p><strong>DPV v2.2</strong> [<a href="2.2/search.html">Search</a>] [<a href="2.2/changelog.html">Changelog</a>]<br/>
     ├── <a href="https://w3c.github.io/dpv/2.2/ai/">ai</a><br>
     ├── <a href="https://w3c.github.io/dpv/2.2/dpv/">dpv</a><br>
     ├── <a href="https://w3c.github.io/dpv/2.2/examples/">examples</a><br>
@@ -97,7 +97,7 @@
     └── <a href="https://w3c.github.io/dpv/2.2/tech/">tech</a>
     </p>
 
-    <p><strong>DPV v2.1</strong><br/>
+    <p><strong>DPV v2.1</strong> [<a href="2.1/search.html">Search</a>] [<a href="2.1/changelog.html">Changelog</a>]<br/>
     ├── <a href="https://w3c.github.io/dpv/2.1/ai/">ai</a><br>
     ├── <a href="https://w3c.github.io/dpv/2.1/dpv/">dpv</a><br>
     ├── <a href="https://w3c.github.io/dpv/2.1/examples/">examples</a><br>
@@ -158,7 +158,7 @@
     └── <a href="https://w3c.github.io/dpv/2.1/tech/">tech</a>
     </p>
 
-    <p><strong>DPV v2.0</strong><br/>
+    <p><strong>DPV v2.0</strong> [<a href="2.0/search.html">Search</a>] [<a href="2.0/changelog.html">Changelog</a>]<br/>
     ├── <a href="https://w3c.github.io/dpv/2.0/ai/">ai</a><br>
     ├── <a href="https://w3c.github.io/dpv/2.0/dpv/">dpv</a><br>
     ├── <a href="https://w3c.github.io/dpv/2.0/examples/">examples</a><br>
@@ -232,7 +232,7 @@
             var purl = url.replace("https://w3c.github.io/dpv/", "https://w3id.org/dpv/")
             span_typo.innerHTML = "check <span class='url'>"+url+"</span> is correct, or its purl form <a href='"+purl+"'>"+purl+"<a/>";
             if (re_check_version.exec(url.replace("https://w3c.github.io/dpv/", "")) == null) {
-                span_unversioned.innerHTML = "you can check whether this versioned form is the url you are looking for: <a href='https://w3c.github.io/dpv/2.1/" + url.replace("https://w3c.github.io/dpv/", "") + "'>https://w3c.github.io/dpv/2.1/" + url.replace("https://w3c.github.io/dpv/", "") + "</a>";
+                span_unversioned.innerHTML = "you can check whether this versioned form is the url you are looking for: <a href='https://w3c.github.io/dpv/2.2/" + url.replace("https://w3c.github.io/dpv/", "") + "'>https://w3c.github.io/dpv/2.2/" + url.replace("https://w3c.github.io/dpv/", "") + "</a>";
             } else {
                 span_unversioned.innerHTML = "but this doesn't appear to be the case";
             }
@@ -240,7 +240,7 @@
             MODE = PAGE_STATUS.DEV;
             span_typo.innerHTML = "check <span class='url'>"+url+"</span> is correct";
             if (re_check_version.exec(url.replace("https://dev.dpvcg/org/", "")) == null) {
-                span_unversioned.innerHTML = "this appears to be an unversioned url, you can check whether this versioned form is the url you are looking for: <a href='https://dev.dpvcg/org/2.1/" + url.replace("https://dev.dpvcg/org/", "") + "'>https://dev.dpvcg/org/2.1/" + url.replace("https://dev.dpvcg/org/", "") + "</a>";
+                span_unversioned.innerHTML = "this appears to be an unversioned url, you can check whether this versioned form is the url you are looking for: <a href='https://dev.dpvcg/org/2.2/" + url.replace("https://dev.dpvcg/org/", "") + "'>https://dev.dpvcg/org/2.2/" + url.replace("https://dev.dpvcg/org/", "") + "</a>";
             } else {
                 span_unversioned.innerHTML = "... but this doesn't appear to be the case";
             }


### PR DESCRIPTION
# Pull Request

Since DPV v2.x already has a search index page and a changelog, add links to those pages to the 404 page, to assist users.

It will look like this (notice the `[Search] [Changelog]` besides the version number):

<img width="827" height="364" alt="Screenshot 2568-08-17 at 23 56 06" src="https://github.com/user-attachments/assets/c96fc565-963c-4a9e-9e16-b662af3cc4dc" />

