### PR TITLE
Use absolute path in logo URL

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,9 +5,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>404 - Resource Not Found</title>
-    <link rel="icon" type="image/x-icon" href="https://w3c.github.io/dpv/diagrams/favicon.ico">
-    <link rel="icon" type="image/png" sizes="32x32" href="https://w3c.github.io/dpv/diagrams/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="https://w3c.github.io/dpv/diagrams/favicon-16x16.png">
+    <link rel="icon" type="image/x-icon" href="https://w3id.org/dpv/diagrams/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://w3id.org/dpv/diagrams/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://w3id.org/dpv/diagrams/favicon-16x16.png">
     <style>
         :root {
             --bg: #ffffff;
@@ -241,7 +241,7 @@
     <div class="site">
         <header>
             <div class="logo">
-                <img src="https://w3c.github.io/dpv/diagrams/logo.png" alt="DPV logo" height="80" width="80" />
+                <img src="https://w3id.org/dpv/diagrams/logo.png" alt="DPV logo" height="80" width="80" />
             </div>
             <div>
                 <h1 id="page-title">404 - Error: Resource Not Found</h1>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Data Privacy Vocabularies and Controls Group (DPVCG)</title>
-    <link rel="icon" type="image/x-icon" href="https://w3c.github.io/dpv/diagrams/favicon.ico">
-    <link rel="icon" type="image/png" sizes="32x32" href="https://w3c.github.io/dpv/diagrams/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="https://w3c.github.io/dpv/diagrams/favicon-16x16.png">
+    <link rel="icon" type="image/x-icon" href="https://w3id.org/dpv/diagrams/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://w3id.org/dpv/diagrams/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://w3id.org/dpv/diagrams/favicon-16x16.png">
     <style>
         :root {
             --bg: #ffffff;
@@ -242,7 +242,7 @@
     <div class="site">
         <header>
             <div class="logo">
-                <img src="https://w3c.github.io/dpv/diagrams/logo.png" alt="DPV logo" height="80" width="80" />
+                <img src="https://w3id.org/dpv/diagrams/logo.png" alt="DPV logo" height="80" width="80" />
             </div>
             <div>
                 <h1 id="page-title">W3C Data Privacy Vocabularies and Controls Group (DPVCG)</h1>


### PR DESCRIPTION
# Pull Request

Replace the relative path in the logo URL with the absolute path

To fix https://github.com/w3c/dpv/issues/420
