### PR TITLE
add documentation to EHDS and Sector templates

### DIFF
--- a/code/jinja2_resources/template_legal_eu_ehds.jinja2
+++ b/code/jinja2_resources/template_legal_eu_ehds.jinja2
@@ -87,43 +87,45 @@
 
   <section id="vocab-data">
     <h2>Data</h2>
-    <p>This section contains concepts representing the categories of data described in the EHDS. In future iterations, the DPVCG is interested in further refining this vocabulary by aligning the concepts with those from [[DPV]] - in particular to establish personal data that are sensitive, and personal data that are classified as special category for use with the [[EU-GDPR]] extension. The DPVCG is also interested to align and enhance the categories of personal data with the [[PD]] extension, and the [[SECTOR-HEALTH]] sectorial extension which models generic healthcare concepts.</p>
+    <p>This section contains concepts representing the categories of data described in the EHDS. The EHDS defines 'electronic health data', which encompasses both personal and non-personal electronic health data. Furthermore, Article 14 defines priority categories of personal electronic health data for primary use, and Article 51 establishes the minimum categories of electronic health data for secondary use. In the next iteration of this extension, the categories of Article 14 and 51 will be aligned with the [[EHDS]] concepts of personal and non-personal electronic health data.</p>
+    <p>In future iterations, the DPVCG is interested in further refining this vocabulary by aligning the concepts with those from [[DPV]] - in particular to establish personal data that are sensitive, and personal data that are classified as special category for use with the [[EU-GDPR]] extension. The DPVCG is also interested to align and enhance the categories of personal data with the [[PD]] extension, and the [[SECTOR-HEALTH]] sectorial extension which models generic healthcare concepts.</p>
     {{ list_hierarchy(modules['data']['classes']) }}
   </section>
 
   <section id="vocab-entities">
     <h2>Entities</h2>
-    <p>This section contains concepts representing the categories and roles of entities described in the EHDS. In future iterations, the DPVCG is interested in further refining this vocabulary by aligning the concepts with those from [[DPV]] - in particular to establish entities that are non-commercial or non-profit in nature, or are research organisations, as well as to represent commonly occurring entity categories such as hospitals, clinics, and other relevant concepts in alignment with the [[SECTOR-HEALTH]] sectorial extension which models generic healthcare concepts.</p>
+    <p>This section contains concepts representing the categories and roles of legal entities described in the EHDS. In future iterations, the DPVCG is interested in further refining this vocabulary by aligning the concepts with those from [[DPV]] - in particular to establish entities that are non-commercial or non-profit in nature, or are research organisations, as well as to represent commonly occurring entity categories such as hospitals, clinics, and other relevant concepts in alignment with the [[SECTOR-HEALTH]] sectorial extension which models generic healthcare concepts.</p>
     {{ list_hierarchy(modules['entities']['classes']) }}
   </section>
 
   <section id="vocab-purposes">
     <h2>Purposes</h2>
-    <p>This section contains concepts representing the categories of purposes described in the EHDS. In future iterations, the DPVCG is interested in further refining this vocabulary by aligning the concepts with those from [[DPV]] - in particular to establish purposes that can be considered as relevant to the provision of healthcare, or for public benefit, or are necessary for medical research. The DPVCG is also interested to align and enhance the categories of purposes with the [[SECTOR-HEALTH]] sectorial extension which models generic healthcare concepts.</p>
+    <p>This section contains concepts representing the categories of purposes described in the EHDS. Article 2.2(d) defines purposes for the processing of electronic health data for primary use, while Article 53 establishes the purposes for which electronic health data can be processed for secondary use. The DPVCG is interested in providing guidance on how to use these concepts to express primary and secondary use scenarios.</p>
+    <p>In future iterations, the DPVCG is interested in further refining this vocabulary by aligning the concepts with those from [[DPV]] - in particular to establish purposes that can be considered as relevant to the provision of healthcare, or for public benefit, or are necessary for medical research. The DPVCG is also interested to align and enhance the categories of purposes with the [[SECTOR-HEALTH]] sectorial extension which models generic healthcare concepts.</p>
     {{ list_hierarchy(modules['purposes']['classes']) }}
   </section>
 
   <section id="vocab-process">
     <h2>Processes</h2>
-    <p>This section contains miscellaneous concepts that can be considered as processes under the EHDS. These will be changed in future versions of the extension. The current concepts of 'data request' and 'data permit' represent the mechanisms through which data is to be requested and through which it will be permitted to be used. The DPVCG is interested in modelling these in terms of specific activities - including how to request, how to express information in a request, lifecycle of a request (e.g. request made, being considered, accepted, or refused), and the accompanying assessments (request validity, risk/impact assessment), and documentation (request log, request report). Likewise, the use of data will also require specific concepts that model such specific processes and artefacts. Further, the DPVCG is interested in establishing specific legal bases and mechanisms that are crucial for the implementation of the EHDS, including its alignment with other extensions implementing regulations such as [[EU-GDPR]] and [[EU-DGA]].</p>
+    <p>This section contains miscellaneous concepts that can be considered as processes under the EHDS. These will be changed in future versions of the extension. The current concepts of 'health data request' and 'data permit' represent the mechanisms through which data is to be requested and through which it will be permitted to be used. The DPVCG is interested in modelling these in terms of specific activities - including how to request, how to express information in a request, lifecycle of a request (e.g., request made, being considered, accepted, or refused), and the accompanying assessments (request validity, risk/impact assessment), and documentation (request log, request report). Likewise, the use of data will also require specific concepts that model such specific processes and artefacts. Further, the DPVCG is interested in establishing specific legal bases and mechanisms that are crucial for the implementation of the EHDS, including its alignment with other extensions implementing regulations such as [[EU-GDPR]] and [[EU-DGA]].</p>
     {{ list_hierarchy(modules['process']['classes']) }}
   </section>
 
   <section id="vocab-technology">
     <h2>Technologies</h2>
-    <p>This section contains concepts regarding the technologies mentioned in the EHDS regulation. These will be changed in future versions of the extension. Concepts to technologies are also provided in [[TECH]] (generic) and [[SECTOR-HEALTH]] (health-specific).</p>
+    <p>This section contains concepts regarding the technologies mentioned in the EHDS regulation, namely related to EHR systems, wellness applications, and data access services. These will be changed in future versions of the extension. Concepts related to technologies are also provided in [[TECH]] (generic) and [[SECTOR-HEALTH]] (health-specific).</p>
     {{ list_hierarchy(modules['technology']['classes']) }}
   </section>
 
   <section id="vocab-rights">
     <h2>Rights</h2>
-    <p></p>
+    <p>This section provides concepts representing several rights to natural and legal persons whose applicability depends on the context and nature of processing taking place. In addition to these concepts, the DPVCG is interested in providing additional concepts, e.g., impacts on rights and justifications, and documentation related to the exercising and management of these rights. Furthermore, the DPVCG is interested in the alignment of these rights with rights from other extensions implementing regulations such as the [[EU-GDPR]] and [[EU-DGA]].</p>
     {{ list_hierarchy(modules['rights']['classes']) }}
   </section>
 
   <section id="vocab-TOM">
     <h2>Tech/Org Measures</h2>
-    <p>This section contains concepts regarding the technical and organisational measures mentioned in the EHDS regulation. These will be changed in future versions of the extension. Concepts are also provided in [[DPV]] (generic) and [[SECTOR-HEALTH]] (health-specific).</p>
+    <p>This section contains concepts regarding the technical and organisational measures mentioned in the EHDS regulation. These will be changed in future versions of the extension. Concepts are also provided in [[DPV]] (generic) and [[SECTOR-HEALTH]] (health-specific). In this context, the DPVCG is interested in providing guidelines on how to express information related to activities reported by a digital health authority, documentation of EHR systems or databases of EHR systems and wellness applications.</p>
     {{ list_hierarchy(modules['TOM']['classes']) }}
   </section>
 

--- a/code/jinja2_resources/template_sector.jinja2
+++ b/code/jinja2_resources/template_sector.jinja2
@@ -72,6 +72,12 @@
     <p>The Data Privacy Vocabulary (DPV) and its extensions provide concepts intended for <i>general</i> use-cases which have a wide applicability. The SECTOR extensions provide concepts <i>specific to a sector</i> to support the use of DPV within that sector. At the moment, these extensions only provide <i>Purposes</i> which extend the DPV's Purpose taxonomy. The DPVCG plans to provide additional sector specific concepts in the future - such as <i>Data categories</i>, <i>Technical and Organisational Measures</i>, <i>Risks and Impacts</i>, and <i>Technologies</i> - and <a href="https://www.w3.org/groups/cg/dpvcg/">welcomes contributions and participation</a> for these.</p>
   </section>
 
+  <section id="vocab-data">
+    <h2>Data</h2>
+    <p>The Data taxonomy provides concepts for representing data, including personal and non-personal data, as well as other data types. Where relevant, these concepts extend the data concepts defined in [[DPV]] and the categories of personal data defined within the [[PD]] extension. The relation <code>dpv:hasData</code> is useful to associate the data concept with a specific context or concept.</p>
+    {{ list_hierarchy(modules['data']['classes']) }}
+  </section>
+
   <section id="vocab-purposes">
     <h2>Purposes</h2>
     <p>The Purpose taxonomy provides concepts for representing purposes for processing data or using technologies within the context of the specific sector. Where relevant, these concepts extend the purpose concepts defined in the (main or core) <a href="../../dpv/">DPV specification</a>. The relation <code>dpv:hasPurpose</code> is useful to associate the purpose with a specific context or concept.</p>
@@ -85,6 +91,12 @@
     {{ list_hierarchy(modules['entities']['classes']) }}
   </section>
   {% endif %}
+
+  <section id="vocab-technology">
+    <h2>Technologies</h2>
+    <p>The Technology taxonomy provides concepts for representing technologies, including software and hardware, as well as other technologies. Where relevant, these concepts extend the data concepts defined in [[DPV]] and the technologies defined within the [[TECH]] extension. The relation <code>dpv:isImplementedUsingTechnology</code> is useful to indicate that something is implemented using some technology.</p>
+    {{ list_hierarchy(modules['technology']['classes']) }}
+  </section>
 
   {% if 'status' in modules %}
   <section id="vocab-status">


### PR DESCRIPTION
I kept the text on the Sector template pretty generic, as I understand that we don't have sector-specific extensions yet. We should add a Health Sector template for v2.4.